### PR TITLE
[Feat #17] 이메일 인증 시스템 구현 및 인증 코드 발급 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/exception/UserNotFoundException.java
@@ -1,6 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.user.exception;
 
-import gnu.capstone.G_Learn_E.global.error.exception.NotFoundGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.NotFoundGroupException;
 
 public class UserNotFoundException extends NotFoundGroupException {
     public UserNotFoundException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package gnu.capstone.G_Learn_E.domain.user.exception;
+
+import gnu.capstone.G_Learn_E.global.error.exception.NotFoundGroupException;
+
+public class UserNotFoundException extends NotFoundGroupException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+
+    public static UserNotFoundException userNotFound(){
+        return new UserNotFoundException("해당 사용자를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.user.service;
 
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.user.exception.UserNotFoundException;
 import gnu.capstone.G_Learn_E.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +18,7 @@ public class UserService {
     public User findById(Long id) {
         // TODO: 예외처리 변경
         return userRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+                .orElseThrow(UserNotFoundException::userNotFound);
     }
     public User findById(String id) {
         long lid;

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -1,0 +1,13 @@
+package gnu.capstone.G_Learn_E.global.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -1,8 +1,17 @@
 package gnu.capstone.G_Learn_E.global.auth.controller;
 
+import gnu.capstone.G_Learn_E.global.auth.dto.response.EmailAuthCode;
+import gnu.capstone.G_Learn_E.global.auth.service.AuthService;
+import gnu.capstone.G_Learn_E.global.auth.util.EmailValidator;
+import gnu.capstone.G_Learn_E.global.jwt.JwtUtils;
+import gnu.capstone.G_Learn_E.global.mail.EmailSender;
+import gnu.capstone.G_Learn_E.global.template.RestTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -10,4 +19,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+    private final EmailValidator emailValidator;
+    private final EmailSender emailSender;
+    private final JwtUtils jwtUtils;
+
+    @GetMapping("/email-code")
+    public RestTemplate<?> getEmailAuthCode(@RequestParam String email) {
+        // TODO : 이메일 검증
+        emailValidator.validate(email);
+        // TODO : 이메일 인증 코드 발급
+        String authCode = authService.issueEmailAuthCode(email);
+        emailSender.sendAuthCode(email, authCode);
+
+        return new RestTemplate<>(HttpStatus.NO_CONTENT, "이메일 인증 코드 발급 성공", null);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/response/EmailAuthCode.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/response/EmailAuthCode.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.global.auth.dto.response;
+
+public record EmailAuthCode(
+        String authCode
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
@@ -1,0 +1,25 @@
+package gnu.capstone.G_Learn_E.global.auth.exception;
+
+import gnu.capstone.G_Learn_E.global.error.exception.client.InvalidGroupException;
+
+public class AuthInvalidException extends InvalidGroupException {
+    public AuthInvalidException(String message) {
+        super(message);
+    }
+
+    public static AuthInvalidException existsUser() {
+        return new AuthInvalidException("이미 존재하는 유저입니다.");
+    }
+
+    public static AuthInvalidException existsEmailAuthCode() {
+        return new AuthInvalidException("이미 인증 코드가 발급된 이메일입니다.");
+    }
+
+    public static AuthInvalidException invalidEmailDomain() {
+        return new AuthInvalidException("유효하지 않은 이메일 도메인 입니다.");
+    }
+
+    public static AuthInvalidException invalidEmailFormat() {
+        return new AuthInvalidException("유효하지 않은 이메일 형식 입니다.");
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/EmailAuthCodeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/EmailAuthCodeRepository.java
@@ -1,0 +1,11 @@
+package gnu.capstone.G_Learn_E.global.auth.repository.email;
+
+public interface EmailAuthCodeRepository {
+    void save(String email, String authCode);
+    String findByEmail(String email);
+
+    boolean exists(String email, String authCode);
+
+    void deleteByEmail(String email);
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
@@ -1,0 +1,67 @@
+package gnu.capstone.G_Learn_E.global.auth.repository.email;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository {
+
+    private final long expirationTime; // 밀리초 단위 (ex. 5분: 5 * 60 * 1000)
+
+    private final Map<String, EmailAuthInfo> emailAuthCodeMap = new ConcurrentHashMap<>();
+
+    public InMemoryEmailAuthCodeRepository(
+            @Value("${auth.email-auth-code-expiration-time}") long expirationTime
+    ) {
+        this.expirationTime = expirationTime;
+    }
+
+    @Override
+    public void save(String email, String authCode) {
+        emailAuthCodeMap.put(email, new EmailAuthInfo(authCode, System.currentTimeMillis()));
+    }
+
+    @Override
+    public String findByEmail(String email) {
+        EmailAuthInfo info = emailAuthCodeMap.get(email);
+        if (info == null || isExpired(info.timestamp)) {
+            emailAuthCodeMap.remove(email); // 만료되었으면 제거
+            return null;
+        }
+        return info.code;
+    }
+
+    @Override
+    public boolean exists(String email, String authCode) {
+        EmailAuthInfo info = emailAuthCodeMap.get(email);
+        if (info == null || isExpired(info.timestamp)) {
+            emailAuthCodeMap.remove(email); // 만료되었으면 제거
+            return false;
+        }
+        return info.code.equals(authCode);
+    }
+
+    @Override
+    public void deleteByEmail(String email) {
+        emailAuthCodeMap.remove(email);
+    }
+
+    private boolean isExpired(long timestamp) {
+        return System.currentTimeMillis() - timestamp >= expirationTime;
+    }
+
+    // 주기적으로 만료된 인증 코드 정리 (예: 1분마다)
+    @Scheduled(fixedDelay = 60 * 1000) // 1분 간격
+    public void cleanUpExpiredCodes() {
+        emailAuthCodeMap.entrySet().removeIf(entry ->
+                isExpired(entry.getValue().timestamp)
+        );
+    }
+
+    // 내부 저장용 클래스
+    private record EmailAuthInfo(String code, long timestamp) { }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
@@ -15,9 +15,9 @@ public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository 
     private final Map<String, EmailAuthInfo> emailAuthCodeMap = new ConcurrentHashMap<>();
 
     public InMemoryEmailAuthCodeRepository(
-            @Value("${auth.email-auth-code-expiration-time}") long expirationTime
+            @Value("${mail-auth.code.expiration-time}") long expirationTime
     ) {
-        this.expirationTime = expirationTime;
+        this.expirationTime = expirationTime * 60 * 1000; // 분을 밀리초로 변환
     }
 
     @Override

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Repository
+@Repository("inMemoryEmailAuthCodeRepository")
 public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository {
 
     private final long expirationTime; // 밀리초 단위 (ex. 5분: 5 * 60 * 1000)

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/refresh/RefreshTokenRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/refresh/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.global.auth.repository.refresh;
+
+public interface RefreshTokenRepository {
+    void save(Long userId, String refreshToken);
+    String findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
@@ -1,0 +1,52 @@
+package gnu.capstone.G_Learn_E.global.auth.service;
+
+import gnu.capstone.G_Learn_E.domain.user.repository.UserRepository;
+import gnu.capstone.G_Learn_E.global.auth.exception.AuthInvalidException;
+import gnu.capstone.G_Learn_E.global.auth.repository.email.EmailAuthCodeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    @Qualifier("inMemoryEmailAuthCodeRepository")
+    private final EmailAuthCodeRepository emailAuthCodeRepository;
+
+    private final UserRepository userRepository;
+
+    private final Random random = new Random();
+
+    /**
+     * 이메일 인증 코드 발급
+     * @param email 이메일
+     * @return 인증 코드 (6자리 숫자)
+     */
+    public String issueEmailAuthCode(String email) {
+        if(userRepository.existsByEmail(email)) {
+            // 이미 가입된 이메일인 경우
+            log.info("이미 가입된 이메일입니다. [email: {}]", email);
+            throw AuthInvalidException.existsUser();
+        }
+        if(emailAuthCodeRepository.findByEmail(email) != null) {
+            // 이미 인증 코드가 발급된 이메일인 경우
+            log.info("이미 인증 코드가 발급된 이메일입니다. [email: {}]", email);
+            throw AuthInvalidException.existsEmailAuthCode();
+        }
+        String authCode = generateEmailAuthCode();
+        emailAuthCodeRepository.save(email, authCode);
+        log.info("이메일 인증 코드 발급 성공 [email: {}, authCode: {}]", email, authCode);
+        return authCode;
+    }
+
+
+    private String generateEmailAuthCode() {
+        // 6자리 숫자로 구성된 인증 코드 생성
+        return String.format("%06d", random.nextInt(1000000));
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import gnu.capstone.G_Learn_E.global.auth.repository.email.EmailAuthCodeReposito
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
@@ -19,6 +20,9 @@ public class AuthService {
     private final EmailAuthCodeRepository emailAuthCodeRepository;
 
     private final UserRepository userRepository;
+
+    @Value("${mail-auth.code.length}")
+    private int emailAuthCodeLength;
 
     private final Random random = new Random();
 
@@ -47,6 +51,6 @@ public class AuthService {
 
     private String generateEmailAuthCode() {
         // 6자리 숫자로 구성된 인증 코드 생성
-        return String.format("%06d", random.nextInt(1000000));
+        return String.valueOf(random.nextInt((int) Math.pow(10, emailAuthCodeLength)));
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/util/EmailValidator.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/util/EmailValidator.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.global.auth.util;
 
 import gnu.capstone.G_Learn_E.global.auth.exception.AuthInvalidException;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -9,7 +10,7 @@ import java.util.List;
 @Component
 @ConfigurationProperties(prefix = "mail-auth")
 public class EmailValidator {
-
+    @Setter
     private List<String> allowedDomain;
 
     public void validate(String email) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/util/EmailValidator.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/util/EmailValidator.java
@@ -1,0 +1,35 @@
+package gnu.capstone.G_Learn_E.global.auth.util;
+
+import gnu.capstone.G_Learn_E.global.auth.exception.AuthInvalidException;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "mail-auth")
+public class EmailValidator {
+
+    private List<String> allowedDomain;
+
+    public void validate(String email) {
+        if (!isValidFormat(email)) {
+            throw AuthInvalidException.invalidEmailFormat();
+        }
+
+        if (!allowedDomain.contains(extractDomain(email))) {
+            throw AuthInvalidException.invalidEmailDomain();
+        }
+    }
+
+    private boolean isValidFormat(String email) {
+        return email != null && email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+    }
+
+    private String extractDomain(String email) {
+        int atIdx = email.lastIndexOf("@");
+        return (atIdx != -1 && atIdx < email.length() - 1)
+                ? email.substring(atIdx + 1)
+                : "";
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/ControllerAdvice.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/ControllerAdvice.java
@@ -1,10 +1,11 @@
 package gnu.capstone.G_Learn_E.global.error;
 
 import gnu.capstone.G_Learn_E.global.error.dto.ErrorResponse;
-import gnu.capstone.G_Learn_E.global.error.exception.AccessDeniedGroupException;
-import gnu.capstone.G_Learn_E.global.error.exception.AuthGroupException;
-import gnu.capstone.G_Learn_E.global.error.exception.InvalidGroupException;
-import gnu.capstone.G_Learn_E.global.error.exception.NotFoundGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.AccessDeniedGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.AuthGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.InvalidGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.NotFoundGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.server.InternalServerErrorGroupException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -55,6 +56,18 @@ public class ControllerAdvice {
 
 
     // 429, ManyRequestsGroupException
+
+
+    // 500, InternalServerError
+    @ExceptionHandler({InternalServerErrorGroupException.class})
+    public ResponseEntity<ErrorResponse> handleInternalServerDate(RuntimeException e) {
+        return createErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+
+    // 502, BadGatewayGroupException
+
+
 
 
     // 메서드 인자 문제 생겼을 때

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/AccessDeniedGroupException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/AccessDeniedGroupException.java
@@ -1,4 +1,4 @@
-package gnu.capstone.G_Learn_E.global.error.exception;
+package gnu.capstone.G_Learn_E.global.error.exception.client;
 
 public abstract class AccessDeniedGroupException extends RuntimeException {
     public AccessDeniedGroupException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/AuthGroupException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/AuthGroupException.java
@@ -1,4 +1,4 @@
-package gnu.capstone.G_Learn_E.global.error.exception;
+package gnu.capstone.G_Learn_E.global.error.exception.client;
 
 public abstract class AuthGroupException extends RuntimeException {
     public AuthGroupException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/InvalidGroupException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/InvalidGroupException.java
@@ -1,4 +1,4 @@
-package gnu.capstone.G_Learn_E.global.error.exception;
+package gnu.capstone.G_Learn_E.global.error.exception.client;
 
 public abstract class InvalidGroupException extends RuntimeException {
     public InvalidGroupException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/NotFoundGroupException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/client/NotFoundGroupException.java
@@ -1,4 +1,4 @@
-package gnu.capstone.G_Learn_E.global.error.exception;
+package gnu.capstone.G_Learn_E.global.error.exception.client;
 
 public abstract class NotFoundGroupException extends RuntimeException {
     public NotFoundGroupException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/server/InternalServerErrorGroupException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/exception/server/InternalServerErrorGroupException.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.global.error.exception.server;
+
+public class InternalServerErrorGroupException extends RuntimeException {
+    public InternalServerErrorGroupException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/jwt/JwtAuthenticationFilter.java
@@ -3,7 +3,7 @@ package gnu.capstone.G_Learn_E.global.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
-import gnu.capstone.G_Learn_E.global.error.exception.NotFoundGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.NotFoundGroupException;
 import gnu.capstone.G_Learn_E.global.jwt.dto.SubjectAndType;
 import gnu.capstone.G_Learn_E.global.jwt.exception.JwtAuthException;
 import gnu.capstone.G_Learn_E.global.security.SecurityPathProperties;

--- a/src/main/java/gnu/capstone/G_Learn_E/global/jwt/exception/JwtAuthException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/jwt/exception/JwtAuthException.java
@@ -1,6 +1,6 @@
 package gnu.capstone.G_Learn_E.global.jwt.exception;
 
-import gnu.capstone.G_Learn_E.global.error.exception.AuthGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.AuthGroupException;
 
 public class JwtAuthException extends AuthGroupException {
     public JwtAuthException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/mail/EmailSender.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/mail/EmailSender.java
@@ -15,10 +15,12 @@ public class EmailSender {
     private final JavaMailSender mailSender;
     private final String expirationTimeMessage;
 
-    public EmailSender(JavaMailSender mailSender,
-                       @Value("${auth.email-auth-code-expiration-time}") long expirationTime) {
+    public EmailSender(
+            JavaMailSender mailSender,
+            @Value("${mail-auth.code.expiration-time}") long expirationTime // 분 단위
+    ) {
         this.mailSender = mailSender;
-        this.expirationTimeMessage = String.valueOf(expirationTime / 1000 / 60);
+        this.expirationTimeMessage = String.valueOf(expirationTime);
     }
 
     public void sendAuthCode(String toEmail, String authCode) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/mail/EmailSender.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/mail/EmailSender.java
@@ -1,0 +1,47 @@
+package gnu.capstone.G_Learn_E.global.mail;
+
+import gnu.capstone.G_Learn_E.global.mail.exception.MailInternalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class EmailSender {
+
+    private final JavaMailSender mailSender;
+    private final String expirationTimeMessage;
+
+    public EmailSender(JavaMailSender mailSender,
+                       @Value("${auth.email-auth-code-expiration-time}") long expirationTime) {
+        this.mailSender = mailSender;
+        this.expirationTimeMessage = String.valueOf(expirationTime / 1000 / 60);
+    }
+
+    public void sendAuthCode(String toEmail, String authCode) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("[G-Learn-E] 이메일 인증 코드");
+        message.setText(buildEmailBody(authCode));
+
+        try {
+            mailSender.send(message);
+            log.info("인증 코드 메일 전송 완료: {}", toEmail);
+        } catch (Exception e) {
+            log.error("인증 코드 메일 전송 실패: {}", toEmail, e);
+            throw MailInternalException.sendFail();
+        }
+    }
+
+    private String buildEmailBody(String code) {
+        return String.format(
+                "G-Learn-E 인증 코드입니다.\n\n" +
+                        "아래 인증 코드를 입력하여 이메일 인증을 완료해주세요.\n\n" +
+                        "인증 코드: %s\n\n" +
+                        "이 코드는 %s분간 유효합니다.", code, expirationTimeMessage
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/mail/exception/MailInternalException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/mail/exception/MailInternalException.java
@@ -1,0 +1,13 @@
+package gnu.capstone.G_Learn_E.global.mail.exception;
+
+import gnu.capstone.G_Learn_E.global.error.exception.server.InternalServerErrorGroupException;
+
+public class MailInternalException extends InternalServerErrorGroupException {
+    public MailInternalException(String message) {
+        super(message);
+    }
+
+    public static MailInternalException sendFail(){
+        return new MailInternalException("메일 전송에 실패하였습니다.");
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/SecurityAccessDeniedException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/SecurityAccessDeniedException.java
@@ -1,6 +1,6 @@
 package gnu.capstone.G_Learn_E.global.security.exception;
 
-import gnu.capstone.G_Learn_E.global.error.exception.AccessDeniedGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.AccessDeniedGroupException;
 
 public class SecurityAccessDeniedException extends AccessDeniedGroupException {
     public SecurityAccessDeniedException(String message) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/SecurityAuthException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/SecurityAuthException.java
@@ -1,6 +1,6 @@
 package gnu.capstone.G_Learn_E.global.security.exception;
 
-import gnu.capstone.G_Learn_E.global.error.exception.AuthGroupException;
+import gnu.capstone.G_Learn_E.global.error.exception.client.AuthGroupException;
 
 public class SecurityAuthException extends AuthGroupException {
     public SecurityAuthException(String message) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,18 @@ spring:
       format_sql: true
     open-in-view: false
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${spring.mail.username}
+    password: ${spring.mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 
 jwt:
   secret: ${jwt.secret}
@@ -30,16 +42,12 @@ jwt:
     access-token: ${jwt.expiration-time.access-token}
     refresh-token: ${jwt.expiration-time.refresh-token}
 
-#  @Getter
-#  @Setter
-#  @Configuration
-#  @ConfigurationProperties(prefix = "security.path")
-#  public class SecurityPathProperties {
-#  private List<String> permitAll;
-#  private List<String> authenticated;
-#  private List<String> anonymous;
-#  private String anyRequest;
-#}
+
+mail-auth:
+  allowed-domain:
+    - gnu.ac.kr
+
+
 security:
   path:
     permit-all:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,9 @@ jwt:
 
 
 mail-auth:
+  code:
+    expiration-time: ${mail-auth.code.expiration-time}
+    length: ${mail-auth.code.length}
   allowed-domain:
     - gnu.ac.kr
 


### PR DESCRIPTION
## #️⃣ Issue Number  
#17

## 📝 요약 (Summary)  
이메일 인증 기능을 위한 전체적인 시스템을 설계하고 구현하였습니다.  
이 기능은 회원가입 시 이메일 유효성 검사 및 인증을 통해 사용자 검증을 강화하기 위해 도입되었습니다.  

다음과 같은 작업이 포함되어 있습니다:

- 이메일 인증 요청을 위한 컨트롤러 및 서비스 계층 구현  
- 인증 코드 생성, 저장, 중복 발급 방지 및 만료 처리  
- Gmail SMTP 연동을 통한 인증 코드 전송 기능 구현  
- 인증에 필요한 예외 처리 계층 및 메시지 일원화  
- `application.yml` 설정 추가 (메일 서버, 인증 코드 유효시간 및 도메인 제한)  
- 전반적인 예외 계층 구조 리팩토링 및 정리  

## 🛠️ PR 유형  

- [x] 새로운 기능 추가  
- [x] 코드 리팩토링  
- [x] 주석 추가 및 수정  
- [x] 문서 수정  
- [x] 테스트 추가, 테스트 리팩토링  
- [x] 빌드 부분 혹은 패키지 매니저 수정  


## 📝 상세 설명 (Details)

### 1. 이메일 인증 요청 API 추가
- `GET /api/auth/email-code?email={email}` 요청 시  
  - 이메일 형식 및 도메인 유효성 검사  
  - 사용자 존재 여부 검사 (이미 가입된 이메일은 인증 불가)  
  - 기존 발급된 인증 코드 존재 시 중복 발급 제한  
  - 유효한 이메일에 대해 인증 코드 생성 후 메일 발송  
  - 인증 코드 저장 (임시 In-Memory 저장소)  
  - 인증 메일 전송 실패 시 서버 예외 발생

### 2. 인증 코드 저장소 (`EmailAuthCodeRepository`)
- `InMemoryEmailAuthCodeRepository` 구현체 등록  
- 인증 코드는 ConcurrentHashMap에 저장되며, 타임스탬프 기반 만료 처리  
- 1분마다 만료된 코드 자동 제거 (스케줄러 활용)  
- 추후 Redis 등 외부 캐시 시스템으로 확장 가능하도록 인터페이스 기반 설계  

### 3. 예외 처리 통일 및 리팩토링
- 예외 그룹을 `client`, `server` 패키지로 분리  
- `AuthInvalidException`, `MailInternalException` 등 구체적 예외 정의  
- `@ControllerAdvice`에 새 예외 그룹 매핑 추가  
- 기존 `UserService`의 예외 처리도 `UserNotFoundException`으로 변경

### 4. 이메일 유효성 검증
- 이메일 형식 정규표현식 검사  
- `mail-auth.allowed-domain`에 명시된 도메인만 허용 (현재 `gnu.ac.kr`)  
- 유효하지 않은 이메일 형식/도메인 요청 시 클라이언트 예외 발생

### 5. 설정 (`application.yml`)
```yaml
mail:
  host: smtp.gmail.com
  port: 587
  username: ${spring.mail.username}
  password: ${spring.mail.password}
  properties:
    mail:
      smtp:
        auth: true
        starttls:
          enable: true

mail-auth:
  code:
    expiration-time: ${mail-auth.code.expiration-time} # 분 단위
    length: ${mail-auth.code.length}                   # 인증 코드 길이 (6)
  allowed-domain:
    - gnu.ac.kr
```

### 6. 기타
- 인증 메일 제목/본문은 `EmailSender` 내부에서 포맷팅 처리  
- `build.gradle`에 `spring-boot-starter-mail` 의존성 추가  
- 로그 남기기 추가 (`@Slf4j` 활용)  
- 기존 코드에 불필요한 주석 및 미사용 예외 import 제거  


## 📸 스크린샷 (선택)  

### 인증코드 전송
![image](https://github.com/user-attachments/assets/ad068852-be61-4d14-8abe-65a881abdb73)

### 인증코드 확인
![image](https://github.com/user-attachments/assets/8b5d0596-629d-4dd4-8161-71d90ac440d1)


## 💬 공유사항 to 리뷰어  
