### PR TITLE
[Feat #17] 이메일 인증코드 검증 API

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.global.auth.controller;
 
-import gnu.capstone.G_Learn_E.global.auth.dto.response.EmailAuthCode;
+import gnu.capstone.G_Learn_E.global.auth.dto.request.EmailAuthCodeVerify;
+import gnu.capstone.G_Learn_E.global.auth.dto.response.EmailAuthToken;
 import gnu.capstone.G_Learn_E.global.auth.service.AuthService;
 import gnu.capstone.G_Learn_E.global.auth.util.EmailValidator;
 import gnu.capstone.G_Learn_E.global.jwt.JwtUtils;
@@ -9,10 +10,7 @@ import gnu.capstone.G_Learn_E.global.template.RestTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -34,5 +32,18 @@ public class AuthController {
         emailSender.sendAuthCode(email, authCode);
 
         return new RestTemplate<>(HttpStatus.NO_CONTENT, "이메일 인증 코드 발급 성공", null);
+    }
+
+    @PostMapping("/email-code/verify")
+    public RestTemplate<EmailAuthToken> verifyEmailAuthCode(@RequestBody EmailAuthCodeVerify request) {
+        // TODO : 이메일 인증 코드 검증
+        authService.verifyEmailAuthCode(request.email(), request.authCode());
+
+        String emailAuthToken = jwtUtils.generateEmailAuthToken(request.email());
+        log.info("이메일 인증 코드 검증 성공 [email: {}]", request.email());
+        log.info("이메일 인증 토큰 발급 [email: {}, token: {}]", request.email(), emailAuthToken);
+
+        String responseMsg = String.format("이메일 인증 코드 검증 성공. 유효 시간: %d분", jwtUtils.getEmailAuthTokenExpiration() / 1000 / 60);
+        return new RestTemplate<>(HttpStatus.OK, responseMsg, new EmailAuthToken(emailAuthToken));
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/EmailAuthCodeVerify.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/EmailAuthCodeVerify.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.global.auth.dto.request;
+
+public record EmailAuthCodeVerify(
+    String email,
+    String authCode
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/response/EmailAuthToken.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/response/EmailAuthToken.java
@@ -1,6 +1,6 @@
 package gnu.capstone.G_Learn_E.global.auth.dto.response;
 
-public record EmailAuthCode(
-        String authCode
+public record EmailAuthToken(
+        String emailAuthToken
 ) {
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
@@ -15,6 +15,10 @@ public class AuthInvalidException extends InvalidGroupException {
         return new AuthInvalidException("이미 인증 코드가 발급된 이메일입니다.");
     }
 
+    public static AuthInvalidException invalidEmailAuthCode() {
+        return new AuthInvalidException("유효하지 않은 인증 코드 입니다. 인증 코드를 재발급 해주세요.");
+    }
+
     public static AuthInvalidException invalidEmailDomain() {
         return new AuthInvalidException("유효하지 않은 이메일 도메인 입니다.");
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/InMemoryEmailAuthCodeRepository.java
@@ -42,7 +42,13 @@ public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository 
             emailAuthCodeMap.remove(email); // 만료되었으면 제거
             return false;
         }
-        return info.code.equals(authCode);
+        if(!info.code.equals(authCode)){
+            // 인증 코드가 일치하지 않는 경우
+            // 인증 코드를 삭제하고 false 반환
+            deleteByEmail(email);
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
@@ -48,6 +48,15 @@ public class AuthService {
         return authCode;
     }
 
+    public void verifyEmailAuthCode(String email, String authCode) {
+        if(!emailAuthCodeRepository.exists(email, authCode)) {
+            log.info("이메일 인증 코드 검증 실패 [email: {}, authCode: {}]", email, authCode);
+            throw AuthInvalidException.invalidEmailAuthCode();
+        }
+        emailAuthCodeRepository.deleteByEmail(email);
+        log.info("이메일 인증 코드 검증 성공 [email: {}, authCode: {}]", email, authCode);
+    }
+
 
     private String generateEmailAuthCode() {
         // 6자리 숫자로 구성된 인증 코드 생성

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/util/EmailValidator.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/util/EmailValidator.java
@@ -7,10 +7,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Setter
 @Component
 @ConfigurationProperties(prefix = "mail-auth")
 public class EmailValidator {
-    @Setter
     private List<String> allowedDomain;
 
     public void validate(String email) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/jwt/JwtUtils.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/jwt/JwtUtils.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -22,8 +23,11 @@ import java.util.Map;
 public class JwtUtils {
 
     private final SecretKey key;
+    @Getter
     private final long emailAuthTokenExpiration; // 이메일 인증코드용 토큰
+    @Getter
     private final long accessTokenExpiration;
+    @Getter
     private final long refreshTokenExpiration;
 
     public JwtUtils(
@@ -37,6 +41,7 @@ public class JwtUtils {
         this.accessTokenExpiration = accessTokenExpiration;
         this.refreshTokenExpiration = refreshTokenExpiration;
     }
+
 
     public String generateAccessToken(User user) {
         return generateToken(user, accessTokenExpiration, "access");


### PR DESCRIPTION
## #️⃣ Issue Number  
#17

## 📝 요약 (Summary)  
이메일 인증 절차의 **2단계**인 "인증 코드 검증 API"를 구현하였습니다.  
이전 PR에서 구현된 이메일 인증 코드 발급 API에 이어, 사용자가 전달한 인증 코드의 유효성을 검증하고, 성공 시 이메일 인증 전용 토큰을 발급합니다.

## 🛠️ PR 유형  

- [x] 새로운 기능 추가  
- [x] 코드 리팩토링  
- [x] 주석 추가 및 수정  

## 📝 상세 설명 (Details)

### 1. **이메일 인증 코드 검증 API 추가**
- `POST /api/auth/email-code/verify`  
- 요청 바디:  
  ```json
  {
    "email": "example@gnu.ac.kr",
    "authCode": "123456"
  }
  ```
- 처리 로직:  
  1. `EmailAuthCodeRepository.exists(email, authCode)`를 통해 유효성 확인  
  2. 코드가 만료되었거나 불일치 시 예외 발생  
  3. 성공 시 인증 코드를 삭제하여 재사용 방지  
  4. `emailAuthToken`(JWT)을 생성하여 반환  
  5. 토큰 유효시간은 `application.yml` 설정 기반

### 2. **JWT 유틸 기능 확장**
- `generateEmailAuthToken(email)` 메서드를 통해 이메일 인증 전용 토큰 발급  
- `emailAuthTokenExpiration` 필드를 `@Getter`로 노출하여 외부 접근 허용  

### 3. **DTO 추가**
- 요청: `EmailAuthCodeVerify` record (email, authCode)  
- 응답: `EmailAuthToken` record (emailAuthToken)  

### 4. **예외 메시지 추가**
- 인증 코드가 유효하지 않을 때 사용자에게 전달할 예외 메시지 추가:
  - `"유효하지 않은 인증 코드 입니다. 인증 코드를 재발급 해주세요."`

### 5. **인증 코드 검증 실패 시 동작**
- 인증 코드가 일치하지 않을 경우, 해당 코드 즉시 삭제 → 재시도 시 재발급 유도

## 📸스크린샷 (선택)  

1. 인증코드 전송
![image](https://github.com/user-attachments/assets/09f43435-8556-44eb-8a76-9c30b1c7aa0f)

2. 인증코드 확인
![image](https://github.com/user-attachments/assets/1b0deb88-33ab-4d80-ae3d-b481d6ffcae4)

3. 인증코드 검증
![image](https://github.com/user-attachments/assets/bfefb8ef-73bd-4835-bd0b-82b703efb5af)

결과 : 회원가입 용 JWT 토큰 발급 성공


## 💬 공유사항 to 리뷰어  