### PR TITLE
[Feat #17] 이메일 인증 기반 로그인/회원가입 API 및 관련 예외/보안 로직 구현

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -20,22 +20,24 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private String name;
+
     @Column(unique = true, nullable = false)
     private String nickname;
 
     @Column(unique = true, nullable = false)
     private String email;
 
-    @Column
+    @Column(nullable = false)
+    private String password;
+
     private Integer profileImage;
 
-    @Column
     private Short level;
 
-    @Column
     private Integer exp;
 
-    @Column
     private UserStatus status;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -48,9 +50,11 @@ public class User {
     private List<SolvedWorkbook> solvedWorkbooks = new ArrayList<>();
 
     @Builder
-    public User(String nickname, String email){
+    public User(String name, String nickname, String email, String password) {
+        this.name = name;
         this.nickname = nickname;
         this.email = email;
+        this.password = password;
         this.profileImage = 0;
         this.level = 1;
         this.exp = 0;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/exception/UserInvalidException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/exception/UserInvalidException.java
@@ -1,0 +1,21 @@
+package gnu.capstone.G_Learn_E.domain.user.exception;
+
+import gnu.capstone.G_Learn_E.global.error.exception.client.InvalidGroupException;
+
+public class UserInvalidException extends InvalidGroupException {
+    public UserInvalidException(String message) {
+        super(message);
+    }
+
+    public static UserInvalidException requestInvalid() {
+        return new UserInvalidException("요청이 올바르지 않습니다.");
+    }
+
+    public static UserInvalidException existsEmail() {
+        return new UserInvalidException("이미 존재하는 이메일입니다.");
+    }
+
+    public static UserInvalidException existsNickname() {
+        return new UserInvalidException("이미 존재하는 닉네임입니다.");
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -11,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findUserByEmail(String email);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -1,10 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.user.service;
 
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.user.exception.UserInvalidException;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserNotFoundException;
 import gnu.capstone.G_Learn_E.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -13,10 +15,31 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+    public User save(String name, String nickname, String email, String password) {
+        if(existsByEmail(email)) {
+            throw UserInvalidException.existsEmail();
+        }
+        if(existsByNickname(nickname)) {
+            throw UserInvalidException.existsNickname();
+        }
+
+        User user = User.builder()
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .build();
+        return userRepository.save(user);
+    }
 
 
+    // find --------------------------------------------------------------------------------------------
     public User findById(Long id) {
-        // TODO: 예외처리 변경
         return userRepository.findById(id)
                 .orElseThrow(UserNotFoundException::userNotFound);
     }
@@ -25,10 +48,19 @@ public class UserService {
         try {
             lid = Long.parseLong(id);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("id는 숫자로 입력해주세요.");
+            throw UserInvalidException.requestInvalid();
         }
-        // TODO: 예외처리 변경
         return userRepository.findById(lid)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+                .orElseThrow(UserNotFoundException::userNotFound);
     }
+
+
+    // exists ------------------------------------------------------------------------------------------
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+    public boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package gnu.capstone.G_Learn_E.global.auth.controller;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
 import gnu.capstone.G_Learn_E.global.auth.dto.request.EmailAuthCodeVerify;
+import gnu.capstone.G_Learn_E.global.auth.dto.request.LoginRequest;
 import gnu.capstone.G_Learn_E.global.auth.dto.request.SignupRequest;
 import gnu.capstone.G_Learn_E.global.auth.dto.response.EmailAuthToken;
 import gnu.capstone.G_Learn_E.global.auth.dto.response.TokenResponse;
@@ -30,6 +31,25 @@ public class AuthController {
     private final EmailValidator emailValidator;
     private final EmailSender emailSender;
     private final JwtUtils jwtUtils;
+
+
+    @PostMapping("/login")
+    public RestTemplate<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        String email = request.email();
+        String password = request.password();
+
+        User user = authService.login(email, password);
+
+        // TODO : 리프레시 토큰 저장 로직 추가
+        String accessToken = jwtUtils.generateAccessToken(user);
+        String refreshToken = jwtUtils.generateRefreshToken(user);
+
+        log.info("로그인 성공 [accessToken : {}, refreshToken : {}]", accessToken, refreshToken);
+        log.info("[email: {}]", email);
+
+        TokenResponse tokenResponse = new TokenResponse(accessToken, refreshToken);
+        return new RestTemplate<>(HttpStatus.OK, "로그인 성공", tokenResponse);
+    }
 
     @PostMapping("/signup")
     public RestTemplate<TokenResponse> signUp(HttpServletRequest request, @Valid @RequestBody SignupRequest dto) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -1,12 +1,19 @@
 package gnu.capstone.G_Learn_E.global.auth.controller;
 
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.user.service.UserService;
 import gnu.capstone.G_Learn_E.global.auth.dto.request.EmailAuthCodeVerify;
+import gnu.capstone.G_Learn_E.global.auth.dto.request.SignupRequest;
 import gnu.capstone.G_Learn_E.global.auth.dto.response.EmailAuthToken;
+import gnu.capstone.G_Learn_E.global.auth.dto.response.TokenResponse;
+import gnu.capstone.G_Learn_E.global.auth.exception.AuthInvalidException;
 import gnu.capstone.G_Learn_E.global.auth.service.AuthService;
 import gnu.capstone.G_Learn_E.global.auth.util.EmailValidator;
 import gnu.capstone.G_Learn_E.global.jwt.JwtUtils;
 import gnu.capstone.G_Learn_E.global.mail.EmailSender;
 import gnu.capstone.G_Learn_E.global.template.RestTemplate;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,13 +25,42 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final UserService userService;
     private final AuthService authService;
     private final EmailValidator emailValidator;
     private final EmailSender emailSender;
     private final JwtUtils jwtUtils;
 
+    @PostMapping("/signup")
+    public RestTemplate<TokenResponse> signUp(HttpServletRequest request, @Valid @RequestBody SignupRequest dto) {
+        // 회원가입
+        String name = dto.name();
+        String nickname = dto.nickname();
+        String email = dto.email();
+        String password = dto.password();
+
+        // 토큰 이메일과 입력받은 이메일 검증
+        String tokenEmail = (String) request.getAttribute("email");
+        if(!email.equals(tokenEmail)) {
+            // TODO : 예외 처리
+            throw AuthInvalidException.emailAndTokenNotMatch();
+        }
+
+        User savedUser = userService.save(name, nickname, email, password);
+
+        // TODO : 리프레시 토큰 저장 로직 추가
+        String accessToken = jwtUtils.generateAccessToken(savedUser);
+        String refreshToken = jwtUtils.generateRefreshToken(savedUser);
+
+        log.info("회원가입 성공 [accessToken : {}, refreshToken : {}]", accessToken, refreshToken);
+        log.info("[name: {}, nickname: {}, email: {}]", name, nickname, email);
+
+        TokenResponse tokenResponse = new TokenResponse(accessToken, refreshToken);
+        return new RestTemplate<>(HttpStatus.CREATED, "회원가입 성공", tokenResponse);
+    }
+
     @GetMapping("/email-code")
-    public RestTemplate<?> getEmailAuthCode(@RequestParam String email) {
+    public RestTemplate<?> getEmailAuthCode(@RequestParam("email") String email) {
         // TODO : 이메일 검증
         emailValidator.validate(email);
         // TODO : 이메일 인증 코드 발급

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/LoginRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package gnu.capstone.G_Learn_E.global.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/SignupRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/SignupRequest.java
@@ -1,0 +1,28 @@
+package gnu.capstone.G_Learn_E.global.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @NotBlank(message = "이름을 입력해주세요.")
+        @Size(min = 2, max = 5, message = "이름은 2~5자 사이로 입력해주세요.")
+        String name,
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 20, message = "닉네임은 2~20자 사이로 입력해주세요.")
+        String nickname,
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=])[A-Za-z\\d!@#$%^&*()_+\\-=]{8,20}$",
+                message = "비밀번호는 8~20자, 영문+숫자+특수문자를 포함해야 합니다."
+        )
+        String password
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/response/TokenResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/response/TokenResponse.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.global.auth.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
@@ -16,7 +16,7 @@ public class AuthInvalidException extends InvalidGroupException {
     }
 
     public static AuthInvalidException invalidEmailAuthCode() {
-        return new AuthInvalidException("유효하지 않은 인증 코드 입니다. 인증 코드를 재발급 해주세요.");
+        return new AuthInvalidException("유효하지 않은 인증 코드 입니다.");
     }
 
     public static AuthInvalidException invalidEmailDomain() {
@@ -25,5 +25,9 @@ public class AuthInvalidException extends InvalidGroupException {
 
     public static AuthInvalidException invalidEmailFormat() {
         return new AuthInvalidException("유효하지 않은 이메일 형식 입니다.");
+    }
+
+    public static AuthInvalidException emailAndTokenNotMatch() {
+        return new AuthInvalidException("이메일 인증 토큰과 요청 이메일이 일치하지 않습니다.");
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthInvalidException.java
@@ -7,10 +7,18 @@ public class AuthInvalidException extends InvalidGroupException {
         super(message);
     }
 
+    // 로그인
     public static AuthInvalidException existsUser() {
         return new AuthInvalidException("이미 존재하는 유저입니다.");
     }
 
+    public static AuthInvalidException passwordNotMatch() {
+        return new AuthInvalidException("비밀번호가 일치하지 않습니다.");
+    }
+
+
+
+    // 이메일 인증
     public static AuthInvalidException existsEmailAuthCode() {
         return new AuthInvalidException("이미 인증 코드가 발급된 이메일입니다.");
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthNotFoundException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthNotFoundException.java
@@ -1,0 +1,17 @@
+package gnu.capstone.G_Learn_E.global.auth.exception;
+
+import gnu.capstone.G_Learn_E.global.error.exception.client.NotFoundGroupException;
+
+public class AuthNotFoundException extends NotFoundGroupException {
+    public AuthNotFoundException(String message) {
+        super(message);
+    }
+
+    public static AuthNotFoundException emailAuthCodeNotFound() {
+        return new AuthNotFoundException("발급된 인증 코드가 존재하지 않습니다.");
+    }
+
+    public static AuthNotFoundException expiredEmailAuthCode() {
+        return new AuthNotFoundException("인증 코드가 만료되었습니다. 인증 코드를 재발급 해주세요.");
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthNotFoundException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/exception/AuthNotFoundException.java
@@ -7,6 +7,10 @@ public class AuthNotFoundException extends NotFoundGroupException {
         super(message);
     }
 
+    public static AuthNotFoundException userNotFound() {
+        return new AuthNotFoundException("유저를 찾을 수 없습니다.");
+    }
+
     public static AuthNotFoundException emailAuthCodeNotFound() {
         return new AuthNotFoundException("발급된 인증 코드가 존재하지 않습니다.");
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/EmailAuthCodeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/repository/email/EmailAuthCodeRepository.java
@@ -1,10 +1,11 @@
 package gnu.capstone.G_Learn_E.global.auth.repository.email;
 
 public interface EmailAuthCodeRepository {
-    void save(String email, String authCode);
-    String findByEmail(String email);
+    void saveAuthCode(String email, String authCode);
 
-    boolean exists(String email, String authCode);
+    boolean isIssuedEmail(String email);
+
+    String findAuthCodeByEmail(String email);
 
     void deleteByEmail(String email);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.global.auth.service;
 
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.repository.UserRepository;
 import gnu.capstone.G_Learn_E.global.auth.exception.AuthInvalidException;
 import gnu.capstone.G_Learn_E.global.auth.exception.AuthNotFoundException;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
@@ -21,11 +23,31 @@ public class AuthService {
     private final EmailAuthCodeRepository emailAuthCodeRepository;
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${mail-auth.code.length}")
     private int emailAuthCodeLength;
 
     private final Random random = new Random();
+
+
+    /**
+     * 로그인
+     * @param email 이메일
+     * @param password 비밀번호
+     * @return 로그인한 유저
+     */
+    public User login(String email, String password) {
+        User user = userRepository.findUserByEmail(email)
+                .orElseThrow(AuthNotFoundException::userNotFound);
+        if(!passwordEncoder.matches(password, user.getPassword())) {
+            log.info("비밀번호가 일치하지 않습니다. [email: {}]", email);
+            throw AuthInvalidException.passwordNotMatch();
+        }
+
+        return user;
+    }
+
 
     /**
      * 이메일 인증 코드 발급

--- a/src/main/java/gnu/capstone/G_Learn_E/global/error/ControllerAdvice.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/error/ControllerAdvice.java
@@ -7,14 +7,15 @@ import gnu.capstone.G_Learn_E.global.error.exception.client.InvalidGroupExceptio
 import gnu.capstone.G_Learn_E.global.error.exception.client.NotFoundGroupException;
 import gnu.capstone.G_Learn_E.global.error.exception.server.InternalServerErrorGroupException;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Objects;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -70,14 +71,45 @@ public class ControllerAdvice {
 
 
 
-    // 메서드 인자 문제 생겼을 때
+    // 400, 파라미터 유효성 오류
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
             final MethodArgumentNotValidException e) {
-        FieldError fieldError = Objects.requireNonNull(e.getFieldError());
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(),
-                String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField()));
-        log.warn("Validation error for field {}: {}", fieldError.getField(), fieldError.getDefaultMessage());
+
+        FieldError fieldError = e.getBindingResult().getFieldErrors().getFirst();
+        String msg = fieldError.getDefaultMessage();
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), msg);
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+
+    /**
+     * 1) 필수 파라미터가 누락되었을 때(MissingServletRequestParameterException)
+     * 예: @RequestParam으로 받는 name 파라미터가 아예 없을 경우
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParams(MissingServletRequestParameterException ex) {
+        // 파라미터 이름
+        String paramName = ex.getParameterName();
+        String message = paramName + "은(는) 필수 파라미터입니다.";
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                message
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 2) 타입이 맞지 않아 생기는 에러(TypeMismatchException, MethodArgumentTypeMismatchException)
+     * 예: double 파라미터 자리에 문자열이 들어온 경우
+     */
+    @ExceptionHandler({TypeMismatchException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(Exception ex) {
+        String message = "파라미터의 타입이 올바르지 않습니다.";
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                message
+        );
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/global/jwt/exception/JwtAuthException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/jwt/exception/JwtAuthException.java
@@ -7,12 +7,20 @@ public class JwtAuthException extends AuthGroupException {
         super(message);
     }
 
+    public static JwtAuthException userNotFound(){
+        return new JwtAuthException("유저를 찾을 수 없습니다.");
+    }
+
     public static JwtAuthException expired(){
         return new JwtAuthException("JWT 토큰이 만료되었습니다.");
     }
 
     public static JwtAuthException invalidToken(){
         return new JwtAuthException("유효하지 않은 JWT 토큰입니다.");
+    }
+
+    public static JwtAuthException emailAuthTokenRequired(){
+        return new JwtAuthException("이메일 인증 완료 토큰이 필요합니다.");
     }
 
     public static JwtAuthException signupTokenNotAllowed(){

--- a/src/main/java/gnu/capstone/G_Learn_E/global/security/SecurityConfig.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/security/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -53,6 +55,12 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/swagger-ui/**", swaggerConfig);       // Swagger UI 전용 설정
         source.registerCorsConfiguration("/v3/api-docs/**", swaggerConfig);      // OpenAPI docs 설정
         return source;
+    }
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/SecurityAccessDeniedException.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/SecurityAccessDeniedException.java
@@ -10,4 +10,8 @@ public class SecurityAccessDeniedException extends AccessDeniedGroupException {
     public static SecurityAccessDeniedException accessDenied() {
         return new SecurityAccessDeniedException("해당 요청에 대한 권한이 없습니다.");
     }
+
+    public static SecurityAccessDeniedException alreadyAuthenticated() {
+        return new SecurityAccessDeniedException("이미 인증된 사용자입니다.");
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/handler/CustomAccessDeniedHandler.java
@@ -1,23 +1,42 @@
 package gnu.capstone.G_Learn_E.global.security.exception.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gnu.capstone.G_Learn_E.global.security.SecurityPathProperties;
 import gnu.capstone.G_Learn_E.global.security.exception.SecurityAccessDeniedException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    // URL에 해당하는 권한이 없을 때 403 Forbidden 에러를 반환
+
+
+    private final SecurityPathProperties securityPathProperties;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        makeAccessDeniedResponse(SecurityAccessDeniedException.accessDenied(), response);
+
+        String requestURI = request.getRequestURI();
+        boolean isAnonymousOnly = securityPathProperties.getAnonymous().stream()
+                .anyMatch(path -> pathMatcher.match(path, requestURI));
+
+        if (isAnonymousOnly) {
+            makeAccessDeniedResponse(SecurityAccessDeniedException.alreadyAuthenticated(), response);
+        } else {
+            makeAccessDeniedResponse(SecurityAccessDeniedException.accessDenied(), response);
+        }
     }
 
     private void makeAccessDeniedResponse(Exception e, HttpServletResponse response) throws IOException {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/security/exception/handler/CustomAuthenticationEntryPoint.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    // 인증되지 않은 사용자가 접근할 때 401 Unauthorized 에러를 반환
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,5 @@ security:
     anonymous:
       - "/api/auth"
     email-auth:
-        - "/api/auth/emailCode"
-        - "/api/auth/emailCode/verify"
+        - "/api/auth/signup"
     any-request: "permit-all"  # 'authenticated', 'permit-all', 'anonymous' 중 하나

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,8 @@ security:
     #      - "/api/notification/**"
     anonymous:
       - "/api/auth"
+      - "/api/auth/login"
+      - "/api/auth/email-auth/**"
     email-auth:
         - "/api/auth/signup"
     any-request: "permit-all"  # 'authenticated', 'permit-all', 'anonymous' 중 하나


### PR DESCRIPTION
## #️⃣ Issue Number  
#17

---

## 📝 요약 (Summary)  
이메일 인증을 기반으로 한 **로그인 및 회원가입 기능 전체 구현**을 완료하였습니다.  
이 PR에서는 다음의 핵심 로직을 포함하고 있습니다:

1. 이메일 인증이 완료된 사용자만 회원가입 가능하도록 설계  
2. 회원가입 시 이름, 닉네임, 이메일, 비밀번호를 포함하여 `User` 엔티티 저장  
3. 이메일 인증 토큰(JWT)을 통해 요청 사용자의 이메일을 식별  
4. 회원가입 후 AccessToken 및 RefreshToken 발급  
5. 예외 처리 강화 및 인증 관련 보안 로직 추가  
6. `EmailAuthCodeRepository` 역할 재정의 및 명확화  
7. 이메일, 비밀번호 기반 로그인 API 개발
8. 인증된 사용자에 대한 미인증 전용 URL 예외처리 추가

---

## 🛠️ PR 유형  
- [x] 새로운 기능 추가  
- [x] 코드 리팩토링  
- [x] 주석 추가 및 수정  
- [x] 예외 처리 개선  
- [x] 빌드/설정 파일 수정  

---

## 📝 상세 설명 (Details)

### ✅ 1. 회원가입 API 추가
- `POST /api/auth/signup`
- 요청 바디:  
  ```json
  {
    "name": "홍길동",
    "nickname": "gildong",
    "email": "hong@gnu.ac.kr",
    "password": "abc123!@#"
  }
  ```
- 처리 로직:
  1. 이메일 인증 토큰을 통해 요청한 이메일과 인증된 이메일 비교  
  2. 이메일, 닉네임 중복 검사  
  3. 비밀번호 암호화 후 유저 저장 (`BCryptPasswordEncoder`)  
  4. AccessToken, RefreshToken 발급  
  5. 응답에 두 토큰 포함 (`TokenResponse`)

### ✅ 2. 이메일 인증 토큰 검증 보안 강화
- `JwtAuthenticationFilter`에서 토큰이 `email-auth` 타입일 경우  
  - `/signup`, `/email-code`, `/email-code/verify` 외의 URI 접근 시 차단  
  - 토큰 없을 경우도 명확한 예외 (`emailAuthTokenRequired`)로 구분  
- 회원가입 시 토큰에서 추출한 이메일과 실제 요청의 이메일 불일치 시 예외 처리 (`emailAndTokenNotMatch`)

### ✅ **3. User 도메인 확장**
- `User` 엔티티에 다음 필드 추가:  
  - `name`: 사용자 실명  
  - `password`: 암호화된 비밀번호  
- `UserService.save()` 오버로딩 추가: 이름/닉네임/이메일/비밀번호를 받아 저장  

### ✅ 4. 예외 클래스 추가 및 리팩토링
- `UserInvalidException`  
  - 이메일/닉네임 중복  
  - 잘못된 ID 형식  
- `AuthNotFoundException`  
  - 인증 코드 없음 / 만료  
- `AuthInvalidException`  
  - 인증 코드 불일치 / 이메일 불일치  

### ✅ 5. EmailAuthCodeRepository 역할 명확화
- 메서드 네이밍 변경:  
  - `save` → `saveAuthCode`  
  - `findByEmail` → `findAuthCodeByEmail`  
  - `exists` → 제거, 직접 검증 방식으로 변경  
- 인증 코드 발급 시 기존 코드가 있으면 삭제 후 재발급  
- 인증 코드 만료 로직 유지 (`Scheduled` 주기적 제거 포함)  

### ✅ 6. 입력값 유효성 검사
- `SignupRequest` DTO에 검증 어노테이션 적용  
  - 이름: 2~5자  
  - 닉네임: 2~20자  
  - 이메일: 형식 검증  
  - 비밀번호: 영문/숫자/특수문자 포함 8~20자

### ✅ 7. 로그인 API 개발
- `POST /api/auth/login`
- 요청 바디:  
  ```json
  {
    "email": "hong@gnu.ac.kr",
    "password": "abc123!@#"
  }
  ```
- 처리 로직:
  1. 이메일과 비밀번호를 전달받음
  2. 이메일로 유저를 찾아 전달받은 비밀번호와 저장된 비밀번호를 암호화하여 비교 (`BCryptPasswordEncoder`)
  3. AccessToken, RefreshToken 발급  
  4. 응답에 두 토큰 포함 (`TokenResponse`)

---

## 📸 스크린샷 (선택)  

### 회원가입
1. 회원가입용 JWT 토큰 발급
![Screenshot 2025-03-25 at 23-28-29 426572877-67b64ef4-bf7c-4f78-b8f4-0a00f032260f png (PNG 이미지 1202x836 픽셀)](https://github.com/user-attachments/assets/e3b938ee-5a80-49ff-9144-4a3bc0edf144)

2. 발급받은 토큰을 Bearer 헤더에 추가

3. 회원가입 성공
![Screenshot 2025-03-25 at 23-26-10 426572765-9925cf6c-3496-4073-aa04-a460ccc75cba png (PNG 이미지 1210x863 픽셀)](https://github.com/user-attachments/assets/904f73fb-4cea-4a3c-a8bb-8bc153715bef)

### 로그인
![image](https://github.com/user-attachments/assets/5cfe1225-28c9-4480-8611-15c84de3e061)


---

## 💬 공유사항 to 리뷰어
