### PR TITLE
[FEAT #25] 경상대 시간표 Json 업로드

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/GLearnEApplication.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/GLearnEApplication.java
@@ -2,8 +2,10 @@ package gnu.capstone.G_Learn_E;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class GLearnEApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/College.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/College.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.public_folder.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,8 +18,14 @@ public class College {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String name;
 
     @OneToMany(mappedBy = "college", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Department> departments = new ArrayList<>();
+
+    @Builder
+    public College(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/Department.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/Department.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.public_folder.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,11 @@ public class Department {
 
     @OneToMany(mappedBy = "department", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Subject> subjects = new ArrayList<>();
+
+
+    @Builder
+    public Department(String name, College college) {
+        this.name = name;
+        this.college = college;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/Subject.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/Subject.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.public_folder.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,10 @@ public class Subject {
 
     @OneToMany(mappedBy = "subject", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubjectWorkbookMap> subjectWorkbookMaps = new ArrayList<>();
+
+    @Builder
+    public Subject(String name, Department department) {
+        this.name = name;
+        this.department = department;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/CollegeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/CollegeRepository.java
@@ -4,6 +4,9 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CollegeRepository extends JpaRepository<College, Long> {
+    Optional<College> findByName(String name);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/DepartmentRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/DepartmentRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
+    Optional<Department> findByNameAndCollegeId(String name, Long collegeId);
     List<Department> findByCollegeId(Long collegeId);
 }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectRepository.java
@@ -1,6 +1,5 @@
 package gnu.capstone.G_Learn_E.domain.public_folder.repository;
 
-import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +8,6 @@ import java.util.List;
 
 @Repository
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
+    boolean existsByNameAndDepartmentId(String name, Long departmentId);
     List<Subject> findByDepartmentId(Long departmentId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/file_upload/controller/FileUploadController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/file_upload/controller/FileUploadController.java
@@ -1,0 +1,48 @@
+package gnu.capstone.G_Learn_E.global.file_upload.controller;
+
+import gnu.capstone.G_Learn_E.global.file_upload.service.FileUploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/dev/api/fileupload")
+public class FileUploadController {
+
+    private final FileUploadService fileUploadService;
+
+
+    @PostMapping("/upload/public_folder_metadata")
+    public ResponseEntity<String> handleFileUpload(@RequestParam("file") MultipartFile file) {
+        try {
+            String originalFilename = file.getOriginalFilename();
+            long size = file.getSize();
+            System.out.println("파일명: " + originalFilename + ", 크기: " + size);
+
+            // 1. 임시 폴더 생성 및 파일 저장
+            Path tempDir = Files.createTempDirectory("");
+            Path tempFilePath = tempDir.resolve(originalFilename);
+            file.transferTo(tempFilePath.toFile());
+
+            // 2. 비동기로 파일 파싱 + DB 적재
+            fileUploadService.processUploadedFile(tempFilePath);
+
+            return ResponseEntity.ok("파일 업로드 성공, 비동기 처리 시작: " + originalFilename);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("업로드 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/file_upload/service/FileUploadService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/file_upload/service/FileUploadService.java
@@ -1,0 +1,156 @@
+package gnu.capstone.G_Learn_E.global.file_upload.service;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
+import gnu.capstone.G_Learn_E.domain.public_folder.repository.CollegeRepository;
+import gnu.capstone.G_Learn_E.domain.public_folder.repository.DepartmentRepository;
+import gnu.capstone.G_Learn_E.domain.public_folder.repository.SubjectRepository;
+import jakarta.transaction.Transactional;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileUploadService {
+    private final CollegeRepository collegeRepository;
+    private final DepartmentRepository departmentRepository;
+    private final SubjectRepository subjectRepository;
+
+
+    @Async // 비동기로 실행
+    public void processUploadedFile(Path filePath) {
+        log.info("파일 처리 시작: {}", filePath);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try (InputStream is = Files.newInputStream(filePath);
+             JsonParser parser = objectMapper.getFactory().createParser(is)) {
+
+            // 최상위는 { ... } 객체라고 가정
+            if (parser.nextToken() == JsonToken.START_OBJECT) {
+                // 내부 필드를 순회
+                while (parser.nextToken() != JsonToken.END_OBJECT) {
+                    String fieldName = parser.getCurrentName();
+                    // "colleges" 배열을 만나면
+                    if ("colleges".equals(fieldName)) {
+                        parser.nextToken(); // START_ARRAY ( [ )
+
+                        // colleges 배열 파싱
+                        while (parser.nextToken() == JsonToken.START_OBJECT) {
+                            // 한 'CollegeDTO'만큼 파싱
+                            CollegeDTO collegeDto = objectMapper.readValue(parser, CollegeDTO.class);
+
+                            // 이제 이 DTO만 DB에 저장 (메모리에 많이 쌓이지 않음)
+                            saveCollegeAndChildren(collegeDto);
+                        }
+                        // colleges 배열 끝나면 ], 다음 token으로 이동
+                    } else {
+                        // 혹시 다른 필드가 있으면 건너뛰기
+                        parser.skipChildren();
+                    }
+                }
+            }
+            log.info("파일 처리 완료: {}", filePath);
+        } catch (IOException e) {
+            log.error("파일 처리 중 오류: {}", e.getMessage(), e);
+        } finally {
+            // 처리 후 파일 삭제
+            try {
+                Files.deleteIfExists(filePath);
+                log.info("임시 파일 삭제: {}", filePath);
+            } catch (IOException ex) {
+                log.error("파일 삭제 중 오류: {}", ex.getMessage(), ex);
+            }
+        }
+    }
+
+    // 하나의 CollegeDTO(및 하위 departments, subjects)를 DB에 반영
+    @Transactional // 부분 트랜잭션
+    public void saveCollegeAndChildren(CollegeDTO collegeDto) {
+        // [1] College 매핑/조회
+        College college = collegeRepository.findByName(collegeDto.getName())
+                .orElseGet(() -> College.builder()
+                        .name(collegeDto.getName())
+                        .build());
+
+        // 아래처럼 필요시 업데이트 가능 (ex: college.setDescription(...))
+
+        // [2] Department 매핑
+        if (collegeDto.getDepartments() != null) {
+            for (DepartmentDTO deptDto : collegeDto.getDepartments()) {
+                Department department = departmentRepository
+                        .findByNameAndCollegeId(deptDto.getName(), college.getId())
+                        .orElseGet(() -> {
+                            Department build = Department.builder()
+                                    .name(deptDto.getName())
+                                    .college(college)
+                                    .build();
+                            college.getDepartments().add(build);
+                            return build;
+                        });
+
+                // [3] Subject 매핑
+                if (deptDto.getSubjects() != null) {
+                    for (SubjectDTO subjDto : deptDto.getSubjects()) {
+                        // 이미 존재하면 스킵
+                        if (subjectRepository.existsByNameAndDepartmentId(subjDto.getName(), department.getId())) {
+                            continue;
+                        }
+                        Subject subject = Subject.builder()
+                                .name(subjDto.getName())
+                                .department(department)
+                                .build();
+                        department.getSubjects().add(subject);
+                    }
+                }
+            }
+        }
+
+        // 최종 저장
+        collegeRepository.save(college);
+        // Cascade.ALL 설정에 따라 Department / Subject도 함께 반영 가능
+    }
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RootDTO {
+        private List<CollegeDTO> colleges;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class CollegeDTO {
+        private String name;
+        private List<DepartmentDTO> departments;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class DepartmentDTO {
+        private String name;
+        private List<SubjectDTO> subjects;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class SubjectDTO {
+        private String name;
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
#25

## 📝 요약(Summary)
퍼블릭 폴더 엔티티들에 Builder 패턴을 추가하고, 관련 Repository 메서드 개선 및 JSON 파일 업로드를 통한 퍼블릭 폴더 데이터 생성 기능을 구현하였습니다.

교과목 정보 json 파일은 노션 공유페이지에 업로드 해 두었습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 📝 상세 설명(Details)
- **엔티티 개선**:  
  - `College`, `Department`, `Subject` 엔티티에 Lombok의 `@Builder`를 추가하여 객체 생성의 편의성을 높였습니다.
- **Repository 개선**:  
  - 퍼블릭 폴더 관련 Repository(`CollegeRepository`, `DepartmentRepository`, `SubjectRepository`)에 필요한 조회 및 저장 메서드를 추가하여 데이터 처리 효율성을 향상시켰습니다.
- **파일 업로드 기능 추가**:  
  - `FileUploadController`와 `FileUploadService`를 새로 구현하여, JSON 파일을 업로드하면 비동기로 파일을 파싱 후 퍼블릭 폴더 데이터를 DB에 저장하도록 처리하였습니다.  
  - JSON 파일 내 "colleges" 배열을 파싱하여, 각 대학(College), 학과(Department), 과목(Subject) 정보를 순차적으로 저장하며, 처리 완료 후 임시 파일을 삭제하는 로직을 포함하고 있습니다.
- **비동기 처리**:  
  - `@Async` 어노테이션을 사용하여 파일 처리 작업을 비동기로 수행, 서버의 응답성을 유지합니다.

## 📸스크린샷 (선택)

API 테스트
![image](https://github.com/user-attachments/assets/e222328d-7a21-466b-8bfb-4d263330b007)


단과대
![image](https://github.com/user-attachments/assets/d6345280-4cef-4b1c-9960-5dea9acf4032)

학과
![image](https://github.com/user-attachments/assets/89becb78-ec6e-479d-b656-9e7bde97b63a)

과목
![image](https://github.com/user-attachments/assets/6c2b915e-c5e3-4174-b7b0-1b183d9a21ef)


조회 API 테스트
![image](https://github.com/user-attachments/assets/b2256522-a2bb-4747-9cab-84268c5f1fb9)
![image](https://github.com/user-attachments/assets/3d9f8fa4-6783-43ed-a905-93f37d7b5f06)
![image](https://github.com/user-attachments/assets/1714a83b-7cef-40c3-9dbb-ee3dedeab945)



## 💬 공유사항 to 리뷰어