### PR TITLE
[Feat #30] 문제집 생성 API 개발

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/Folder.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/Folder.java
@@ -2,6 +2,7 @@ package gnu.capstone.G_Learn_E.domain.folder.entity;
 
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,6 +40,15 @@ public class Folder {
 
     @PrePersist
     public void prePersist(){
+        this.createdAt = LocalDateTime.now();
+    }
+
+
+    @Builder
+    public Folder(String name, Folder parent, User user) {
+        this.name = name;
+        this.parent = parent;
+        this.user = user;
         this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/FolderWorkbookId.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/FolderWorkbookId.java
@@ -1,14 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.folder.entity;
 
 import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 
 @Getter
+@Builder
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/FolderWorkbookMap.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/FolderWorkbookMap.java
@@ -2,6 +2,7 @@ package gnu.capstone.G_Learn_E.domain.folder.entity;
 
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,13 @@ public class FolderWorkbookMap {
     @JoinColumn(name = "workbook_id")
     private Workbook workbook;
 
+    @Builder
+    public FolderWorkbookMap(Folder folder, Workbook workbook) {
+        this.folder = folder;
+        this.workbook = workbook;
+        this.id = FolderWorkbookId.builder()
+                .folderId(folder.getId())
+                .workbookId(workbook.getId())
+                .build();
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
@@ -1,9 +1,14 @@
 package gnu.capstone.G_Learn_E.domain.folder.repository;
 
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+    Optional<Folder> findByUserAndParentIsNull(User user);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -1,0 +1,98 @@
+package gnu.capstone.G_Learn_E.domain.problem.converter;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.global.common.serialization.Option;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProblemConverter {
+
+    /**
+     * 객관식 문제를 Problem 엔티티로 변환합니다.
+     * @param mc 객관식 문제 DTO
+     * @return 변환된 Problem 엔티티
+     */
+    public static Problem convertToMultipleProblem(
+            ProblemGenerateResponse.MultipleChoice mc, Integer problemNumber) {
+        return Problem.builder()
+                .problemNumber(problemNumber)
+                .title(mc.question())
+                .options(convertOptions(mc.options()))
+                .answers(Collections.singletonList(mc.answer()))
+                .explanation(mc.explanation())
+                .type(ProblemType.MULTIPLE)
+                .build();
+    }
+
+
+    /**
+     * OX 문제를 Problem 엔티티로 변환합니다.
+     * @param ox OX 문제 DTO
+     * @return 변환된 Problem 엔티티
+     */
+    public static Problem convertToOxProblem(ProblemGenerateResponse.Ox ox, Integer problemNumber) {
+        return Problem.builder()
+                .problemNumber(problemNumber)
+                .title(ox.question())
+                .options(null)
+                .answers(Collections.singletonList(ox.answer()))
+                .explanation(ox.explanation())
+                .type(ProblemType.OX)
+                .build();
+    }
+
+    /**
+     * 빈칸 채우기 문제를 Problem 엔티티로 변환합니다.
+     * @param fib 빈칸 채우기 문제 DTO
+     * @return 변환된 Problem 엔티티
+     */
+    public static Problem convertToBlankProblem(ProblemGenerateResponse.FillInTheBlank fib, Integer problemNumber) {
+        return Problem.builder()
+                .problemNumber(problemNumber)
+                .title(fib.question())
+                .options(null)
+                .answers(fib.answer())
+                .explanation(fib.explanation())
+                .type(ProblemType.BLANK)
+                .build();
+    }
+
+    /**
+     * 서술형 문제를 Problem 엔티티로 변환합니다.
+     * @param desc 서술형 문제 DTO
+     * @return 변환된 Problem 엔티티
+     */
+    public static Problem convertToDescriptiveProblem(ProblemGenerateResponse.Descriptive desc, Integer problemNumber) {
+        return Problem.builder()
+                .problemNumber(problemNumber)
+                .title(desc.question())
+                .options(null)
+                .answers(Collections.singletonList(desc.answer()))
+                // 서술형 문제는 해설이 없는 경우도 있음
+                .explanation(null)
+                .type(ProblemType.DESCRIPTIVE)
+                .build();
+    }
+
+
+    /**
+     * 문자열 목록을 Option 객체의 목록으로 변환합니다.
+     * @param optionsList 객관식 보기 문자열 목록
+     * @return Option 객체 목록
+     */
+    private static List<Option> convertOptions(List<String> optionsList) {
+        if (optionsList == null) {
+            return null;
+        }
+        return optionsList.stream()
+                .map(option -> Option.builder()
+                        .number((short) (optionsList.indexOf(option) + 1)) // 1부터 시작하는 번호
+                        .content(option)
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -88,10 +88,10 @@ public class ProblemConverter {
         if (optionsList == null) {
             return null;
         }
-        return optionsList.stream()
-                .map(option -> Option.builder()
-                        .number((short) (optionsList.indexOf(option) + 1)) // 1부터 시작하는 번호
-                        .content(option)
+        return IntStream.range(0, optionsList.size())
+                .mapToObj(i -> Option.builder()
+                        .number((short) (i + 1)) // 1부터 시작하는 번호
+                        .content(optionsList.get(i))
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemResponse.java
@@ -1,0 +1,47 @@
+package gnu.capstone.G_Learn_E.domain.problem.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.global.common.serialization.Option;
+
+import java.util.List;
+
+public record ProblemResponse(
+        Long id, // 문제 ID
+        Integer problemNumber, // 문제 번호
+        String type, // 문제 유형
+        String title, // 문제 제목
+        List<String> options, // 문제 선택지 (객관식 문제에만 해당)
+
+        List<String> answers, // 정답 리스트 (빈칸 복수, 나머지 단일)
+        String explanation // 해설
+) {
+    public static ProblemResponse of(
+            Long id,
+            Integer problemNumber,
+            String type,
+            String title,
+            List<String> options,
+            List<String> answers,
+            String explanation
+    ) {
+        return new ProblemResponse(id, problemNumber, type, title, options, answers, explanation);
+    }
+
+    public static ProblemResponse of(Problem problem) {
+        return of(
+                problem.getId(),
+                problem.getProblemNumber(),
+                problem.getType().name(),
+                problem.getTitle(),
+                problem.getOptions() != null ? problem.getOptions().stream().map(Option::getContent).toList() : null,
+                problem.getAnswers(),
+                problem.getExplanation()
+        );
+    }
+
+    public static List<ProblemResponse> of(List<Problem> problems) {
+        return problems.stream()
+                .map(ProblemResponse::of)
+                .toList();
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
@@ -7,6 +7,7 @@ import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.global.common.serialization.Option;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,10 +22,9 @@ public class Problem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 문제 번호
 
-    private String title;        // 문제 제목
+    private Integer problemNumber; // 문제 번호 (문제집 내에서의 순서)
 
-    @Column(columnDefinition = "TEXT")
-    private String content;      // 문제 본문 내용
+    private String title;        // 문제 제목
 
     @Convert(converter = OptionListConverter.class)
     @Column(columnDefinition = "TEXT")
@@ -47,4 +47,15 @@ public class Problem {
 
     @OneToMany(mappedBy = "problem", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolveLog> solveLogs; // 문제를 푼 사용자들의 풀이 기록
+
+    @Builder
+    public Problem(Integer problemNumber, String title, List<Option> options, List<String> answers,
+                   String explanation, ProblemType type) {
+        this.problemNumber = problemNumber;
+        this.title = title;
+        this.options = options;
+        this.answers = answers;
+        this.explanation = explanation;
+        this.type = type;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -59,7 +59,6 @@ public class User {
         this.level = 1;
         this.exp = 0;
         this.status = UserStatus.ACTIVE;
-        // TODO : 개인 폴더에 루트 디렉터리를 추가해줘야 됨
     }
 
     public void updateProfileImage(Integer profileImage){

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.user.service;
 
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+import gnu.capstone.G_Learn_E.domain.folder.repository.FolderRepository;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserInvalidException;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserNotFoundException;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final FolderRepository folderRepository;
     private final PasswordEncoder passwordEncoder;
 
     public User save(User user) {
@@ -34,7 +37,15 @@ public class UserService {
                 .email(email)
                 .password(passwordEncoder.encode(password))
                 .build();
-        return userRepository.save(user);
+        user = userRepository.save(user);
+
+        Folder folder = Folder.builder()
+                .name("기본 폴더")
+                .user(user)
+                .parent(null)
+                .build();
+        folderRepository.save(folder);
+        return user;
     }
 
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -1,6 +1,9 @@
 package gnu.capstone.G_Learn_E.domain.workbook.controller;
 
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.ProblemGenerateRequest;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.WorkbookResponse;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
@@ -9,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -24,14 +28,20 @@ public class WorkbookController {
 
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, path = "/generate")
-    public ApiResponse<ProblemGenerateResponse> createWorkbook(
+    public ApiResponse<WorkbookResponse> createWorkbook(
+            @AuthenticationPrincipal User user,
             @ModelAttribute ProblemGenerateRequest request
     ) {
 
-        ProblemGenerateResponse problemGenerateResponse = fastApiService.generateProblems(request);
+
+        ProblemGenerateResponse problemGenerateResponse = fastApiService.makeDummyResponse1(request);
         log.info("Response : {}", problemGenerateResponse);
 
+        Workbook workbook = workbookService.createWorkbook(problemGenerateResponse);
+
+        WorkbookResponse response = WorkbookResponse.of(workbook);
+
         // Workbook 생성 로직 처리 후 결과 반환
-        return new ApiResponse<>(HttpStatus.OK, "문제집 생성에 성공하였습니다.", problemGenerateResponse);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 생성에 성공하였습니다.", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -37,7 +37,7 @@ public class WorkbookController {
         ProblemGenerateResponse problemGenerateResponse = fastApiService.makeDummyResponse1(request);
         log.info("Response : {}", problemGenerateResponse);
 
-        Workbook workbook = workbookService.createWorkbook(problemGenerateResponse);
+        Workbook workbook = workbookService.createWorkbook(problemGenerateResponse, user);
 
         WorkbookResponse response = WorkbookResponse.of(workbook);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -1,10 +1,15 @@
 package gnu.capstone.G_Learn_E.domain.workbook.controller;
 
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.ProblemGenerateRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -13,6 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkbookController {
 
     private final WorkbookService workbookService;
+    private final FastApiService fastApiService;
 
     // TODO : 문제집 컨트롤러 구현
+
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, path = "/generate")
+    public ApiResponse<ProblemGenerateResponse> createWorkbook(
+            @ModelAttribute ProblemGenerateRequest request
+    ) {
+
+        ProblemGenerateResponse problemGenerateResponse = fastApiService.generateProblems(request);
+        log.info("Response : {}", problemGenerateResponse);
+
+        // Workbook 생성 로직 처리 후 결과 반환
+        return new ApiResponse<>(HttpStatus.OK, "문제집 생성에 성공하였습니다.", problemGenerateResponse);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/converter/WorkbookConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/converter/WorkbookConverter.java
@@ -1,0 +1,54 @@
+package gnu.capstone.G_Learn_E.domain.workbook.converter;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static gnu.capstone.G_Learn_E.domain.problem.converter.ProblemConverter.*;
+
+public class WorkbookConverter {
+
+    /**
+     * ProblemGenerateResponse DTO를 기반으로 Workbook 객체와 해당 Workbook에 포함될 Problem 엔티티들을 생성합니다.
+     *
+     * @param response Problem 생성 DTO
+     * @param workbook 변환 대상 Workbook 엔티티 (기본 정보는 이미 셋팅되어 있다고 가정)
+     * @return 문제들이 추가된 Workbook 객체
+     */
+    public static Workbook convertToWorkbookAndProblems(ProblemGenerateResponse response, Workbook workbook) {
+        List<Problem> problems = new ArrayList<>();
+
+        Integer problemNumber = 1; // 문제 번호 초기화
+
+        // 1. 객관식 문제 변환
+        for (ProblemGenerateResponse.MultipleChoice mc : response.result().multipleChoice()) {
+            Problem problem = convertToMultipleProblem(mc, problemNumber++);
+            problems.add(problem);
+        }
+
+        // 2. OX 문제 변환
+        for (ProblemGenerateResponse.Ox ox : response.result().ox()) {
+            Problem problem = convertToOxProblem(ox, problemNumber++);
+            problems.add(problem);
+        }
+
+        // 3. 빈칸 채우기 문제 변환
+        for (ProblemGenerateResponse.FillInTheBlank fib : response.result().fillInTheBlank()) {
+            Problem problem = convertToBlankProblem(fib, problemNumber++);
+            problems.add(problem);
+        }
+
+        // 4. 서술형 문제 변환
+        for (ProblemGenerateResponse.Descriptive desc : response.result().descriptive()) {
+            Problem problem = convertToDescriptiveProblem(desc, problemNumber++);
+            problems.add(problem);
+        }
+
+        // Workbook의 문제 목록에 추가 (양방향 연관관계 설정)
+        workbook.getProblems().addAll(problems);
+        return workbook;
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/Content.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/Content.java
@@ -1,0 +1,13 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record Content(
+        String summaryText,
+        MultipartFile pdfFile,
+        MultipartFile audioFile
+) {
+    public static Content of(String summaryText, MultipartFile pdfFile, MultipartFile audioFile) {
+        return new Content(summaryText, pdfFile, audioFile);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/ProblemGenerateRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/ProblemGenerateRequest.java
@@ -1,0 +1,11 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+public record ProblemGenerateRequest(
+        Content content,
+        String difficulty,
+        QuestionTypes questionTypes
+) {
+    public static ProblemGenerateRequest of(Content content, String difficulty, QuestionTypes questionTypes) {
+        return new ProblemGenerateRequest(content, difficulty, questionTypes);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/QuestionTypes.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/QuestionTypes.java
@@ -1,23 +1,13 @@
-package gnu.capstone.G_Learn_E.global.fastapi.dto.request;
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
 
-public record ProblemGenerateRequest(
-        String content,
-        String difficulty,
-        QuestionTypes questionTypes
+public record QuestionTypes(
+        MultipleChoice multipleChoice,
+        Ox ox,
+        FillInTheBlank fillInTheBlank,
+        Descriptive descriptive
 ) {
-    public static ProblemGenerateRequest of(String content, String difficulty, QuestionTypes questionTypes) {
-        return new ProblemGenerateRequest(content, difficulty, questionTypes);
-    }
-
-    public record QuestionTypes(
-            MultipleChoice multipleChoice,
-            Ox ox,
-            FillInTheBlank fillInTheBlank,
-            Descriptive descriptive
-    ) {
-        public static QuestionTypes of(MultipleChoice multipleChoice, Ox ox, FillInTheBlank fillInTheBlank, Descriptive descriptive) {
-            return new QuestionTypes(multipleChoice, ox, fillInTheBlank, descriptive);
-        }
+    public static QuestionTypes of(MultipleChoice multipleChoice, Ox ox, FillInTheBlank fillInTheBlank, Descriptive descriptive) {
+        return new QuestionTypes(multipleChoice, ox, fillInTheBlank, descriptive);
     }
 
     public record MultipleChoice(
@@ -57,3 +47,4 @@ public record ProblemGenerateRequest(
         }
     }
 }
+

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/ProblemGenerateResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/ProblemGenerateResponse.java
@@ -1,4 +1,4 @@
-package gnu.capstone.G_Learn_E.global.fastapi.dto.response;
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookResponse.java
@@ -1,0 +1,43 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemResponse;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+
+import java.util.List;
+
+public record WorkbookResponse(
+        String name, // 워크북 이름
+        String professor, // 교수 이름
+        String examType, // 시험 유형
+        Integer coverImage, // 표지 이미지
+        Integer courseYear, // 수강 연도
+        String semester, // 학기
+        String createdAt, // 생성일
+        List<ProblemResponse> problems // 문제 목록
+) {
+    public static WorkbookResponse of(
+            String name,
+            String professor,
+            String examType,
+            Integer coverImage,
+            Integer courseYear,
+            String semester,
+            String createdAt,
+            List<ProblemResponse> problems
+    ) {
+        return new WorkbookResponse(name, professor, examType, coverImage, courseYear, semester, createdAt, problems);
+    }
+
+    public static WorkbookResponse of(Workbook workbook){
+        return new WorkbookResponse(
+                workbook.getName(),
+                workbook.getProfessor(),
+                workbook.getExamType().name(),
+                workbook.getCoverImage(),
+                workbook.getCourseYear(),
+                workbook.getSemester().name(),
+                workbook.getCreatedAt().toString(),
+                ProblemResponse.of(workbook.getProblems())
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.workbook.entity;
 
+import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
@@ -42,6 +43,9 @@ public class Workbook {
 
     @Column
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FolderWorkbookMap> folderWorkbookMaps = new ArrayList<>();
 
     @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubjectWorkbookMap> subjectWorkbookMaps = new ArrayList<>();

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/ExamType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/ExamType.java
@@ -1,5 +1,9 @@
 package gnu.capstone.G_Learn_E.domain.workbook.enums;
 
 public enum ExamType {
-    ALL, MIDDLE, FINAL, OTHER
+
+    ALL, // 전체 범위
+    MIDDLE, // 중간고사
+    FINAL, // 기말고사
+    OTHER // 기타
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/Semester.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/Semester.java
@@ -1,5 +1,9 @@
 package gnu.capstone.G_Learn_E.domain.workbook.enums;
 
 public enum Semester {
-    SPRING, SUMMER, FALL, WINTER
+    SPRING, // 1학기
+    SUMMER, // 여름 계절학기
+    FALL, // 2학기
+    WINTER, // 겨울 계절학기
+    OTHER // 기타
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -1,9 +1,16 @@
 package gnu.capstone.G_Learn_E.domain.workbook.service;
 
+import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
+import gnu.capstone.G_Learn_E.domain.workbook.enums.Semester;
 import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -11,4 +18,19 @@ import org.springframework.stereotype.Service;
 public class WorkbookService {
 
     private final WorkbookRepository workbookRepository;
+
+
+    public Workbook createWorkbook(ProblemGenerateResponse response){
+        Workbook workbookTemplate = Workbook.builder()
+                .name(LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .professor("교수명")
+                .examType(ExamType.OTHER)
+                .coverImage(1)
+                .courseYear(LocalDateTime.now().getYear())
+                .semester(Semester.OTHER)
+                .build();
+
+        Workbook newWorkbook = WorkbookConverter.convertToWorkbookAndProblems(response, workbookTemplate);
+        return workbookRepository.save(newWorkbook);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -1,5 +1,11 @@
 package gnu.capstone.G_Learn_E.domain.workbook.service;
 
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookId;
+import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookMap;
+import gnu.capstone.G_Learn_E.domain.folder.repository.FolderRepository;
+import gnu.capstone.G_Learn_E.domain.folder.repository.FolderWorkbookMapRepository;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
@@ -18,9 +24,15 @@ import java.time.LocalDateTime;
 public class WorkbookService {
 
     private final WorkbookRepository workbookRepository;
+    private final FolderRepository folderRepository;
+    private final FolderWorkbookMapRepository folderWorkbookMapRepository;
 
 
-    public Workbook createWorkbook(ProblemGenerateResponse response){
+    public Workbook createWorkbook(ProblemGenerateResponse response, User user){
+
+        Folder rootFolder = folderRepository.findByUserAndParentIsNull(user)
+                .orElseThrow(() -> new RuntimeException("기본 폴더가 없습니다."));
+
         Workbook workbookTemplate = Workbook.builder()
                 .name(LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .professor("교수명")
@@ -31,6 +43,15 @@ public class WorkbookService {
                 .build();
 
         Workbook newWorkbook = WorkbookConverter.convertToWorkbookAndProblems(response, workbookTemplate);
-        return workbookRepository.save(newWorkbook);
+        newWorkbook = workbookRepository.save(newWorkbook);
+
+
+        FolderWorkbookMap folderWorkbookMap = FolderWorkbookMap.builder()
+                .folder(rootFolder)
+                .workbook(newWorkbook)
+                .build();
+        folderWorkbookMapRepository.save(folderWorkbookMap);
+
+        return newWorkbook;
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/controller/FastApiController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/controller/FastApiController.java
@@ -1,8 +1,10 @@
 package gnu.capstone.G_Learn_E.global.fastapi.controller;
 
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.QuestionTypes;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeBlankRequest;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeDescriptiveRequest;
-import gnu.capstone.G_Learn_E.global.fastapi.dto.request.ProblemGenerateRequest;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.request.FastApiProblemGenerateRequest;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.response.*;
 import gnu.capstone.G_Learn_E.global.fastapi.enums.PeriodType;
 import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
@@ -10,7 +12,6 @@ import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,14 +30,14 @@ public class FastApiController {
 
     @GetMapping("/test/make-problem")
     public ApiResponse<ProblemGenerateResponse> testMakeProblem() {
-        ProblemGenerateRequest requestDto = ProblemGenerateRequest.of(
+        FastApiProblemGenerateRequest requestDto = FastApiProblemGenerateRequest.of(
                 "스프링부트 프레임워크에 대한 모든것",
                 "하",
-                ProblemGenerateRequest.QuestionTypes.of(
-                        ProblemGenerateRequest.MultipleChoice.of(true, 1, 4),
-                        ProblemGenerateRequest.Ox.of(true, 1),
-                        ProblemGenerateRequest.FillInTheBlank.of(true, 1),
-                        ProblemGenerateRequest.Descriptive.of(true, 1)
+                QuestionTypes.of(
+                        QuestionTypes.MultipleChoice.of(true, 1, 4),
+                        QuestionTypes.Ox.of(true, 1),
+                        QuestionTypes.FillInTheBlank.of(true, 1),
+                        QuestionTypes.Descriptive.of(true, 1)
                 )
         );
         ProblemGenerateResponse problemGenerateResponse = fastApiService.generateProblems(requestDto);

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/AudioToStringRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/AudioToStringRequest.java
@@ -1,0 +1,11 @@
+package gnu.capstone.G_Learn_E.global.fastapi.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record AudioToStringRequest(
+        MultipartFile audioFile
+) {
+    public static AudioToStringRequest of(MultipartFile audioFile) {
+        return new AudioToStringRequest(audioFile);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/FastApiProblemGenerateRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/FastApiProblemGenerateRequest.java
@@ -1,0 +1,13 @@
+package gnu.capstone.G_Learn_E.global.fastapi.dto.request;
+
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.QuestionTypes;
+
+public record FastApiProblemGenerateRequest(
+        String content,
+        String difficulty,
+        QuestionTypes questionTypes
+) {
+    public static FastApiProblemGenerateRequest of(String content, String difficulty, QuestionTypes questionTypes) {
+        return new FastApiProblemGenerateRequest(content, difficulty, questionTypes);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/PdfToStringRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/PdfToStringRequest.java
@@ -1,0 +1,11 @@
+package gnu.capstone.G_Learn_E.global.fastapi.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record PdfToStringRequest(
+        MultipartFile pdfFile
+) {
+    public static PdfToStringRequest of(MultipartFile pdfFile) {
+        return new PdfToStringRequest(pdfFile);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/PdfToStringResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/PdfToStringResponse.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.global.fastapi.dto.response;
+
+public record PdfToStringResponse(
+        String text
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/service/FastApiService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/service/FastApiService.java
@@ -1,17 +1,26 @@
 package gnu.capstone.G_Learn_E.global.fastapi.service;
 
-import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeBlankRequest;
-import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeDescriptiveRequest;
-import gnu.capstone.G_Learn_E.global.fastapi.dto.request.ProblemGenerateRequest;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.ProblemGenerateRequest;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.request.*;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.response.*;
 import gnu.capstone.G_Learn_E.global.fastapi.entity.FastApiProperties;
 import gnu.capstone.G_Learn_E.global.fastapi.enums.PeriodType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -31,10 +40,15 @@ public class FastApiService {
     }
 
 
-    public ProblemGenerateResponse generateProblems(ProblemGenerateRequest request) {
+    public ProblemGenerateResponse generateProblems(FastApiProblemGenerateRequest orgRequest) {
         FastApiProperties.Endpoint endpoint = getEndpoint("create-problem");
         String url = fastApiProperties.baseUrl() + endpoint.path();
 
+        FastApiProblemGenerateRequest request = FastApiProblemGenerateRequest.of(
+                orgRequest.content(),
+                orgRequest.difficulty(),
+                orgRequest.questionTypes()
+        );
         // FastAPI 서버로 POST 요청
         ResponseEntity<ProblemGenerateResponse> response = restTemplate.postForEntity(url, request, ProblemGenerateResponse.class);
         if (response.getStatusCode().is2xxSuccessful()) {
@@ -45,6 +59,70 @@ public class FastApiService {
             throw new RuntimeException("Failed to call FastAPI");
         }
     }
+
+    public ProblemGenerateResponse generateProblems(ProblemGenerateRequest orgRequest) {
+        String summaryText = orgRequest.content().summaryText();
+        MultipartFile pdfFile = orgRequest.content().pdfFile();
+        MultipartFile audioFile = orgRequest.content().audioFile();
+
+        String content = "";
+        if (summaryText != null) {
+            log.info("summaryText: {}", summaryText);
+            content += summaryText;
+        }
+        if (pdfFile != null) {
+            String tmp = pdfToStringRequest(PdfToStringRequest.of(pdfFile));
+            log.info("pdfFile: {}", tmp);
+            content += tmp;
+        }
+        if (audioFile != null) {
+            content += audioToStringRequest(AudioToStringRequest.of(audioFile));
+        }
+        FastApiProblemGenerateRequest request = FastApiProblemGenerateRequest.of(
+                content,
+                orgRequest.difficulty(),
+                orgRequest.questionTypes()
+        );
+        return generateProblems(request);
+    }
+
+    private String pdfToStringRequest(PdfToStringRequest request){
+        try {
+            FastApiProperties.Endpoint endpoint = getEndpoint("pdf-to-string");
+            String url = fastApiProperties.baseUrl() + endpoint.path();
+
+            MultipartFile pdfFile = request.pdfFile();
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("pdfFile", new MultipartInputStreamFileResource(pdfFile.getInputStream(), pdfFile.getOriginalFilename()));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+            // FastAPI 서버에 POST 요청 보내기
+            ResponseEntity<PdfToStringResponse> response = restTemplate.postForEntity(url, requestEntity, PdfToStringResponse.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                System.out.println("Pdf To String response: " + response.getBody());
+                return response.getBody().text();
+            } else {
+                System.err.println("Failed to call FastAPI: " + response.getStatusCode());
+                throw new RuntimeException("Failed to call FastAPI");
+            }
+        } catch (IOException e) {
+            log.error("Error reading PDF file: {}", e.getMessage());
+            throw new RuntimeException("Failed to call FastAPI");
+        }
+
+    }
+
+    private String audioToStringRequest(AudioToStringRequest request){
+
+        return "converted";
+    }
+
+
 
     public GradeDescriptiveResponse gradeDescriptive(GradeDescriptiveRequest request) {
         FastApiProperties.Endpoint endpoint = getEndpoint("grade-descriptive");
@@ -170,5 +248,26 @@ public class FastApiService {
                         )
                 )
         );
+    }
+
+
+    static class MultipartInputStreamFileResource extends InputStreamResource {
+
+        private final String filename;
+
+        public MultipartInputStreamFileResource(InputStream inputStream, String filename) {
+            super(inputStream);
+            this.filename = filename;
+        }
+
+        @Override
+        public String getFilename() {
+            return this.filename;
+        }
+
+        @Override
+        public long contentLength() throws IOException {
+            return -1; // 파일 크기를 모를 경우 -1 반환
+        }
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/service/FastApiService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/service/FastApiService.java
@@ -213,8 +213,29 @@ public class FastApiService {
     }
 
 
+    static class MultipartInputStreamFileResource extends InputStreamResource {
 
-    private ProblemGenerateResponse makeDummyResponse() {
+        private final String filename;
+
+        public MultipartInputStreamFileResource(InputStream inputStream, String filename) {
+            super(inputStream);
+            this.filename = filename;
+        }
+
+        @Override
+        public String getFilename() {
+            return this.filename;
+        }
+
+        @Override
+        public long contentLength() throws IOException {
+            return -1; // 파일 크기를 모를 경우 -1 반환
+        }
+    }
+
+
+
+    public ProblemGenerateResponse makeDummyResponse(ProblemGenerateRequest request) {
         // Dummy Data
         return ProblemGenerateResponse.of(
                 ProblemGenerateResponse.Result.of(
@@ -235,7 +256,7 @@ public class FastApiService {
                         ),
                         List.of(
                                 ProblemGenerateResponse.FillInTheBlank.of(
-                                        "스프링부트는 _____ 프레임워크이다.",
+                                        "스프링부트는 [[$BLANK$]] 프레임워크이다.",
                                         List.of("경량화된"),
                                         "스프링부트는 경량화된 프레임워크입니다."
                                 )
@@ -250,24 +271,63 @@ public class FastApiService {
         );
     }
 
-
-    static class MultipartInputStreamFileResource extends InputStreamResource {
-
-        private final String filename;
-
-        public MultipartInputStreamFileResource(InputStream inputStream, String filename) {
-            super(inputStream);
-            this.filename = filename;
-        }
-
-        @Override
-        public String getFilename() {
-            return this.filename;
-        }
-
-        @Override
-        public long contentLength() throws IOException {
-            return -1; // 파일 크기를 모를 경우 -1 반환
-        }
+    public ProblemGenerateResponse makeDummyResponse1(ProblemGenerateRequest request) {
+        return ProblemGenerateResponse.of(
+                ProblemGenerateResponse.Result.of(
+                        // 객관식 문제 (MultipleChoice)
+                        List.of(
+                                ProblemGenerateResponse.MultipleChoice.of(
+                                        "변환(Transform)의 종류가 아닌 것은 무엇인가?",
+                                        List.of("이동(Translation)", "축소확대(Scaling)", "회전(Rotation)", "왜곡(Deformation)"),
+                                        "4",
+                                        "변환의 세 가지 주요 종류는 이동(Translation), 축소확대(Scaling), 회전(Rotation)입니다. 왜곡(Deformation)은 제시된 변환의 종류에 해당하지 않습니다."
+                                ),
+                                ProblemGenerateResponse.MultipleChoice.of(
+                                        "Affine 변환의 정의에 포함되지 않는 것은 무엇인가?",
+                                        List.of("Linear transform", "Translation", "Rotation", "스케일링(Skew)"),
+                                        "4",
+                                        "Affine 변환은 선형 변환(Linear transform)과 평행 이동(Translation)을 포함하지만, 스케일링(Skew)은 여기에 포함되지 않습니다."
+                                )
+                        ),
+                        // OX 문제 (Ox)
+                        List.of(
+                                ProblemGenerateResponse.Ox.of(
+                                        "모든 물체는Affine Transform을 통해 선형 변환과 평행 이동을 동시에 수행할 수 있다.",
+                                        "O",
+                                        "Affine Transform은 선형 변환(Linear transform)과 평행 이동(Translation)을 포함하여 변환을 수행할 수 있습니다."
+                                ),
+                                ProblemGenerateResponse.Ox.of(
+                                        "3D 회전에서 z축을 중심으로 회전할 때, y좌표는 변화하지 않을 것이다.",
+                                        "O",
+                                        "z축을 중심으로 회전할 때, x와 y좌표는 2차원 회전의 결과와 같고 z좌표는 변화하지 않습니다."
+                                )
+                        ),
+                        // 빈칸 채우기 문제 (FillInTheBlank)
+                        List.of(
+                                ProblemGenerateResponse.FillInTheBlank.of(
+                                        "변환의 범주에는 [[$BLANK$]], [[$BLANK$]], [[$BLANK$]]이 포함됩니다.",
+                                        List.of("Translation", "Rotation", "Scaling"),
+                                        "변환에는 이동(Translation), 회전(Rotation), 축소확대(Scaling)의 세 가지 주요 종류가 있습니다."
+                                ),
+                                ProblemGenerateResponse.FillInTheBlank.of(
+                                        "역변환을 통해 물체의 방향을 복원하기 위해서는 [[$BLANK$]] 행렬을 적용해야 합니다.",
+                                        List.of("역행렬"),
+                                        "물체의 특정 방향으로 회전되었을 때 원래의 방향으로 돌아가기 위해서는 역행렬을 적용해야 합니다."
+                                )
+                        ),
+                        // 서술형 문제 (Descriptive)
+                        List.of(
+                                ProblemGenerateResponse.Descriptive.of(
+                                        "Affine Transform의 개념을 설명하시오.",
+                                        "Affine Transform은 선형 변환(Linear transform)과 평행 이동(Translation)을 포함한 변환으로, 이들은 행렬 형태로 표현되어 여러 변환을 동시에 수행할 수 있습니다."
+                                ),
+                                ProblemGenerateResponse.Descriptive.of(
+                                        "3D Scaling의 정의와 이를 어떻게 적용하는지 설명하시오.",
+                                        "3D Scaling은 물체의 크기를 조정하는 변환으로, 각 정점에 동일한 Scaling Matrix를 적용하여 이루어집니다. 유니폼 Scaling은 모든 방향에 동일한 Scaling Factor를 사용하고, Non-uniform Scaling은 각 방향에 따라 다른 Scaling Factor를 적용합니다."
+                                )
+                        )
+                )
+        );
     }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,11 @@ spring:
             protocols:
               TLSv1.2
 
+  servlet:
+    multipart:
+      max-request-size: 15MB
+      max-file-size: 15MB
+
 
 jwt:
   secret: ${jwt.secret}
@@ -87,6 +92,12 @@ fast-api:
     create-problem:
       method: ${fast-api.endpoints.create-problem.method}
       path: ${fast-api.endpoints.create-problem.path}
+    pdf-to-string:
+      method: ${fast-api.endpoints.pdf-to-string.method}
+      path: ${fast-api.endpoints.pdf-to-string.path}
+    audio-to-string:
+      method: ${fast-api.endpoints.audio-to-string.method}
+      path: ${fast-api.endpoints.audio-to-string.path}
     grade-descriptive:
       method: ${fast-api.endpoints.grade-descriptive.method}
       path: ${fast-api.endpoints.grade-descriptive.path}


### PR DESCRIPTION
## #️⃣ Issue Number  
<!--- ex) #이슈번호 -->  
#30  

---

## 📝 요약(Summary)  
- 유저 생성 시 개인 루트 디렉터리(`Folder`)를 자동 생성  
- 문제집 생성 시 해당 유저의 루트 디렉터리에 자동으로 매핑(`FolderWorkbookMap`)  
- 문제집 생성 API 개선 및 응답 포맷 확장  
- 문제 데이터 구조 및 변환 로직 구현 (`ProblemConverter`, `WorkbookConverter`)  
- FastAPI 요청/응답 분리 및 `PDF`, `오디오` 입력 처리 로직 구현  

---

## 🛠️ PR 유형

- [x] 새로운 기능 추가  
- [x] 코드 리팩토링  
- [ ] 버그 수정  
- [ ] CSS 등 사용자 UI 디자인 변경  
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)  
- [ ] 주석 추가 및 수정  
- [ ] 문서 수정  
- [ ] 빌드 부분 혹은 패키지 매니저 수정  
- [ ] 파일 혹은 폴더명 수정  
- [ ] 파일 혹은 폴더 삭제  

---

## 📝 상세 설명(Details)  

### 📁 폴더(Folder) 관련
- 유저 생성 시 개인 전용 루트 디렉터리 생성 (`UserService`)
- `FolderRepository.findByUserAndParentIsNull()`을 통해 루트 디렉터리 조회 가능

### 📚 문제집(Workbook) 생성 관련
- 문제집 생성 시 자동으로 유저의 루트 폴더에 저장되도록 연동 (`FolderWorkbookMap`)
- 중간 엔티티 `FolderWorkbookMap`에 생성자 추가하여 깔끔하게 생성 가능하도록 개선

### 🧠 문제/문제집 데이터 변환
- `ProblemConverter`를 통한 문제 타입별 객체 변환 로직 구성
- `WorkbookConverter`를 통해 문제집 생성 시 일괄 변환 및 저장 처리

### 🤖 FastAPI 연동 개선
- 텍스트 + PDF + 오디오 입력 조합에 따라 요청 본문 생성
- `pdf-to-string`, `audio-to-string` 엔드포인트 연동 로직 작성

---

## 📸 스크린샷 (선택)  
없음  

---

## 💬 공유사항 to 리뷰어  
없음