### PR TITLE
[Feat #38] 유저 폴더링 시스템

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/controller/FolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/controller/FolderController.java
@@ -1,10 +1,21 @@
 package gnu.capstone.G_Learn_E.domain.folder.controller;
 
+import gnu.capstone.G_Learn_E.domain.folder.dto.request.CreateFolderRequest;
+import gnu.capstone.G_Learn_E.domain.folder.dto.request.MoveFolderRequest;
+import gnu.capstone.G_Learn_E.domain.folder.dto.response.FolderResponse;
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.folder.service.FolderService;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -13,6 +24,79 @@ import org.springframework.web.bind.annotation.RestController;
 public class FolderController {
 
     private final FolderService folderService;
+    private final WorkbookService workbookService;
 
-    // TODO : 폴더 컨트롤러 구현
+
+    @PostMapping
+    public ApiResponse<FolderResponse> createFolder(
+            @AuthenticationPrincipal User user,
+            @RequestBody CreateFolderRequest request
+    ) {
+        log.info("createFolder request: {}", request);
+
+        Folder folder = folderService.createFolder(user, request.name(), request.parentId());
+
+        FolderResponse response = createFolderResponse(folder);
+
+        return new ApiResponse<>(HttpStatus.OK, "폴더 생성에 성공하였습니다.", response);
+    }
+
+    @GetMapping("/{folderId}")
+    public ApiResponse<FolderResponse> getFolder(
+            @AuthenticationPrincipal User user,
+            @PathVariable(name = "folderId") Long folderId
+            ) {
+        log.info("getFolder request: {}", folderId);
+
+        Folder folder = (folderId != null) ?
+                folderService.getFolderWithChildren(user, folderId)
+                : folderService.getRootFolderWithChildren(user);
+
+        FolderResponse response = createFolderResponse(folder);
+
+        return new ApiResponse<>(HttpStatus.OK, "폴더 조회에 성공하였습니다.", response);
+    }
+
+    @GetMapping
+    public ApiResponse<FolderResponse> getFolder(
+            @AuthenticationPrincipal User user
+    ) {
+        Folder folder = folderService.getRootFolderWithChildren(user);
+
+        FolderResponse response = createFolderResponse(folder);
+
+        return new ApiResponse<>(HttpStatus.OK, "폴더 조회에 성공하였습니다.", response);
+    }
+
+
+    @PatchMapping("/{folderId}/move")
+    public ApiResponse<?> moveFolder(
+            @AuthenticationPrincipal User user,
+            @PathVariable(name = "folderId") Long folderId,
+            @RequestBody MoveFolderRequest request
+    ) {
+        log.info("moveFolder request: {}", folderId);
+
+        folderService.moveFolder(user, folderId, request.targetFolderId());
+
+        return new ApiResponse<>(HttpStatus.OK, "폴더 이동에 성공하였습니다.", null);
+    }
+
+
+
+    private FolderResponse createFolderResponse(Folder folder) {
+        List<Folder> childrenFolder = folder.getChildren();
+        List<Workbook> childrenWorkbook = workbookService.getChildrenWorkbooks(folder);
+
+        FolderResponse response = FolderResponse.of(
+                folder.getId(),
+                folder.getName(),
+                folder.getParent() != null ? folder.getParent().getId() : null,
+                folder.getCreatedAt().toString(),
+                childrenFolder,
+                childrenWorkbook
+        );
+        log.info("response: {}", response);
+        return response;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/controller/FolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/controller/FolderController.java
@@ -4,6 +4,8 @@ import gnu.capstone.G_Learn_E.domain.folder.dto.request.CreateFolderRequest;
 import gnu.capstone.G_Learn_E.domain.folder.dto.request.MoveFolderRequest;
 import gnu.capstone.G_Learn_E.domain.folder.dto.request.RenameFolderRequest;
 import gnu.capstone.G_Learn_E.domain.folder.dto.response.FolderResponse;
+import gnu.capstone.G_Learn_E.domain.folder.dto.response.FolderWorkbookRemoveResponse;
+import gnu.capstone.G_Learn_E.domain.folder.dto.response.SimpleFolderResponse;
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.folder.service.FolderService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
@@ -79,9 +81,11 @@ public class FolderController {
     ) {
         log.info("moveFolder request: {}", folderId);
 
-        folderService.moveFolder(user, folderId, request.targetFolderId());
+        Folder folder = folderService.moveFolder(user, folderId, request.targetFolderId());
 
-        return new ApiResponse<>(HttpStatus.OK, "폴더 이동에 성공하였습니다.", null);
+        SimpleFolderResponse response = SimpleFolderResponse.from(folder);
+
+        return new ApiResponse<>(HttpStatus.OK, "폴더 이동에 성공하였습니다.", response);
     }
 
     @PatchMapping("/{folderId}/rename")
@@ -93,7 +97,7 @@ public class FolderController {
         log.info("renameFolder request: {}", folderId);
 
         Folder folder = folderService.renameFolder(user, folderId, request.newFolderName());
-        FolderResponse response = createFolderResponse(folder);
+        SimpleFolderResponse response = SimpleFolderResponse.from(folder);
         return new ApiResponse<>(HttpStatus.OK, "폴더 이름 변경에 성공하였습니다.", response);
     }
 
@@ -107,6 +111,21 @@ public class FolderController {
         folderService.deleteFolder(user, folderId);
 
         return new ApiResponse<>(HttpStatus.OK, "폴더 삭제에 성공하였습니다.", null);
+    }
+
+    @DeleteMapping("/{folderId}/workbook/{workbookId}")
+    public ApiResponse<?> deleteWorkbookFromFolder(
+            @AuthenticationPrincipal User user,
+            @PathVariable(name = "folderId") Long folderId,
+            @PathVariable(name = "workbookId") Long workbookId
+    ) {
+        log.info("deleteWorkbookFromFolder request: {}", folderId);
+
+        boolean isUploadedWorkbook = folderService.deleteWorkbookFromFolder(user, folderId, workbookId);
+
+        FolderWorkbookRemoveResponse response = FolderWorkbookRemoveResponse.of(isUploadedWorkbook);
+
+        return new ApiResponse<>(HttpStatus.OK, "폴더에서 문제집 삭제에 성공하였습니다.", response);
     }
 
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/request/CreateFolderRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/request/CreateFolderRequest.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.request;
+
+public record CreateFolderRequest(
+        String name,
+        Long parentId
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/request/MoveFolderRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/request/MoveFolderRequest.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.request;
+
+public record MoveFolderRequest(
+        Long targetFolderId
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/request/RenameFolderRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/request/RenameFolderRequest.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.request;
+
+public record RenameFolderRequest(
+        String newFolderName
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderResponse.java
@@ -1,0 +1,72 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+
+import java.util.List;
+
+public record FolderResponse(
+        Long id,
+        String name,
+        Long parentId,
+        String createdAt,
+        List<ChildFolderResponse> childFolders,
+        List<ChildWorkbookResponse> childWorkbooks
+) {
+    public static FolderResponse of(Long id, String name, Long parentId, String createdAt,
+                                    List<Folder> childFolders, List<Workbook> childWorkbooks) {
+        return new FolderResponse(
+                id,
+                name,
+                parentId,
+                createdAt,
+                childFolders.stream().map(ChildFolderResponse::of).toList(),
+                childWorkbooks.stream().map(ChildWorkbookResponse::of).toList()
+        );
+    }
+
+    public record ChildFolderResponse(
+            Long id,
+            String name,
+            String createdAt
+    ) {
+        public static ChildFolderResponse of(Long id, String name, String createdAt) {
+            return new ChildFolderResponse(
+                    id,
+                    name,
+                    createdAt
+            );
+        }
+        public static ChildFolderResponse of(Folder folder) {
+            return new ChildFolderResponse(
+                    folder.getId(),
+                    folder.getName(),
+                    folder.getCreatedAt().toString()
+            );
+        }
+    }
+
+    public record ChildWorkbookResponse(
+            Long id,
+            String name,
+            Integer coverImage,
+            String createdAt
+    ) {
+        public static ChildWorkbookResponse of(Long id, String name, Integer coverImage, String createdAt) {
+            return new ChildWorkbookResponse(
+                    id,
+                    name,
+                    coverImage,
+                    createdAt
+            );
+        }
+        public static ChildWorkbookResponse of(Workbook workbook) {
+            return new ChildWorkbookResponse(
+                    workbook.getId(),
+                    workbook.getName(),
+                    workbook.getCoverImage(),
+                    workbook.getCreatedAt().toString()
+            );
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderResponse.java
@@ -50,14 +50,16 @@ public record FolderResponse(
             Long id,
             String name,
             Integer coverImage,
-            String createdAt
+            String createdAt,
+            boolean isUploaded
     ) {
-        public static ChildWorkbookResponse of(Long id, String name, Integer coverImage, String createdAt) {
+        public static ChildWorkbookResponse of(Long id, String name, Integer coverImage, String createdAt, boolean isUploaded) {
             return new ChildWorkbookResponse(
                     id,
                     name,
                     coverImage,
-                    createdAt
+                    createdAt,
+                    isUploaded
             );
         }
         public static ChildWorkbookResponse of(Workbook workbook) {
@@ -65,7 +67,8 @@ public record FolderResponse(
                     workbook.getId(),
                     workbook.getName(),
                     workbook.getCoverImage(),
-                    workbook.getCreatedAt().toString()
+                    workbook.getCreatedAt().toString(),
+                    workbook.isUploaded()
             );
         }
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderTreeResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderTreeResponse.java
@@ -1,0 +1,27 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+
+import java.util.List;
+
+public record FolderTreeResponse(
+        Long id,
+        String name,
+        List<FolderTreeResponse> childFolders
+) {
+    public static FolderTreeResponse of(Long id, String name, List<FolderTreeResponse> childFolders) {
+        return new FolderTreeResponse(
+                id,
+                name,
+                childFolders
+        );
+    }
+
+    public static FolderTreeResponse from(Folder folder) {
+        return new FolderTreeResponse(
+                folder.getId(),
+                folder.getName(),
+                folder.getChildren().stream().map(FolderTreeResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderWorkbookRemoveResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/FolderWorkbookRemoveResponse.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.response;
+
+public record FolderWorkbookRemoveResponse(
+        boolean isUploaded
+) {
+    public static FolderWorkbookRemoveResponse of(boolean isUploaded) {
+        return new FolderWorkbookRemoveResponse(isUploaded);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/SimpleFolderResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/SimpleFolderResponse.java
@@ -1,0 +1,28 @@
+package gnu.capstone.G_Learn_E.domain.folder.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+
+public record SimpleFolderResponse(
+        Long id,
+        String name,
+        Long parentId,
+        String createdAt
+) {
+    public static SimpleFolderResponse of(Long id, String name, Long parentId, String createdAt) {
+        return new SimpleFolderResponse(
+                id,
+                name,
+                parentId,
+                createdAt
+        );
+    }
+
+    public static SimpleFolderResponse from(Folder folder) {
+        return new SimpleFolderResponse(
+                folder.getId(),
+                folder.getName(),
+                folder.getParent().getId(),
+                folder.getCreatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/SimpleFolderResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/dto/response/SimpleFolderResponse.java
@@ -21,7 +21,7 @@ public record SimpleFolderResponse(
         return new SimpleFolderResponse(
                 folder.getId(),
                 folder.getName(),
-                folder.getParent().getId(),
+                folder.getParent() != null ? folder.getParent().getId() : null,
                 folder.getCreatedAt().toString()
         );
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/Folder.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/Folder.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ public class Folder {
 
     private LocalDateTime createdAt;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Folder parent;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/Folder.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/entity/Folder.java
@@ -19,6 +19,7 @@ public class Folder {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     private String name;
 
     private LocalDateTime createdAt;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
@@ -39,4 +39,13 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
 
     List<Folder> findByParentAndUser(Folder parent, User user);
+
+
+    @Query("""
+        SELECT f FROM Folder f
+        LEFT JOIN FETCH f.parent
+        WHERE f.user = :user
+    """)
+    List<Folder> findAllByUserWithParent(@Param("user") User user); // 폴더 트리 조회
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
@@ -12,6 +12,14 @@ import java.util.Optional;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+    // MEMO: JPA 트러블슈팅 메모!!
+    // N+1 문제를 최소화하기 위해 Folder.children은 fetch join (LEFT JOIN FETCH)으로 가져옴
+    // Folder.folderWorkbookMaps는 LAZY 로딩으로 가져옴
+    // → Hibernate는 2개 이상의 List(bag)를 동시에 fetch join할 수 없기 때문에,
+    //    children만 조인하고, workbook 쪽은 필요할 때 Lazy로 한 번만 조회되도록 처리함
+    // children, workbook 둘 중에 뭘 join해서 가져올지는 성능 분석 필요할듯.
+    // (일반적으로 폴더 개수보다 문제집 개수가 더 많으니 workbook 쪽을 join해서 가져오는게 더 나을듯...? 나중에 공부해보고 수정해보기)
+
 
     Optional<Folder> findByUserAndParentIsNull(User user);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
@@ -3,12 +3,32 @@ package gnu.capstone.G_Learn_E.domain.folder.repository;
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Optional<Folder> findByUserAndParentIsNull(User user);
+
+    @Query("""
+        SELECT f FROM Folder f
+        LEFT JOIN FETCH f.children c
+        WHERE f.user = :user AND f.parent IS NULL
+    """)
+    Optional<Folder> findByUserAndParentIsNullWithChildren(@Param("user") User user);
+
+    @Query("""
+        SELECT DISTINCT f FROM Folder f
+        LEFT JOIN FETCH f.children
+        WHERE f.id = :id
+    """)
+    Optional<Folder> findByIdWithChildren(@Param("id") Long id);
+
+
+    List<Folder> findByParentAndUser(Folder parent, User user);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderWorkbookMapRepository.java
@@ -1,9 +1,24 @@
 package gnu.capstone.G_Learn_E.domain.folder.repository;
 
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookMap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FolderWorkbookMapRepository extends JpaRepository<FolderWorkbookMap, Long> {
+
+    List<FolderWorkbookMap> findByFolder(Folder folder);
+
+
+    @Query("""
+        SELECT m FROM FolderWorkbookMap m
+        JOIN FETCH m.workbook
+        WHERE m.folder = :folder
+    """)
+    List<FolderWorkbookMap> findByFolderWithWorkbook(@Param("folder") Folder folder);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderWorkbookMapRepository.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.folder.repository;
 
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
+import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookId;
 import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookMap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface FolderWorkbookMapRepository extends JpaRepository<FolderWorkbookMap, Long> {
+public interface FolderWorkbookMapRepository extends JpaRepository<FolderWorkbookMap, FolderWorkbookId> {
 
     List<FolderWorkbookMap> findByFolder(Folder folder);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -73,6 +75,12 @@ public class FolderService {
             throw new IllegalArgumentException("You do not have permission to access this folder");
         }
         return folder;
+    }
+
+    @Transactional
+    public List<Folder> getFolderTree(User user) {
+        log.info("getFolderTree request");
+        return folderRepository.findAllByUserWithParent(user);
     }
 
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
@@ -1,7 +1,10 @@
 package gnu.capstone.G_Learn_E.domain.folder.service;
 
+import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.folder.repository.FolderRepository;
 import gnu.capstone.G_Learn_E.domain.folder.repository.FolderWorkbookMapRepository;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,5 +17,94 @@ public class FolderService {
     private final FolderRepository folderRepository;
     private final FolderWorkbookMapRepository folderWorkbookMapRepository;
 
-    // TODO : 폴더 서비스 구현
+
+    public Folder createFolder(User user, String folderName, Long parentId) {
+        log.info("createFolder request: {}", folderName);
+        if (parentId == null) {
+            throw new IllegalArgumentException("Parent folder ID cannot be null");
+        }
+
+        Folder parentFolder = folderRepository.findById(parentId)
+                .orElseThrow(() -> new IllegalArgumentException("Parent folder not found"));
+
+        if (!parentFolder.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("You do not have permission to create a folder in this parent folder");
+        }
+
+        Folder folder = Folder.builder()
+                .name(folderName)
+                .user(user)
+                .parent(parentFolder)
+                .build();
+
+        return folderRepository.save(folder);
+    }
+
+    public Folder getRootFolder(User user) {
+        log.info("getRootFolder request");
+        return folderRepository.findByUserAndParentIsNull(user)
+                .orElseThrow(() -> new IllegalArgumentException("Root folder not found"));
+    }
+    public Folder getRootFolderWithChildren(User user) {
+        // Children만 left join으로 가져옴
+        log.info("getRootFolder request");
+        return folderRepository.findByUserAndParentIsNullWithChildren(user)
+                .orElseThrow(() -> new IllegalArgumentException("Root folder not found"));
+    }
+
+    public Folder getFolder(User user, Long folderId) {
+        log.info("getFolder request: {}", folderId);
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new IllegalArgumentException("Folder not found"));
+        if(!folder.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("You do not have permission to access this folder");
+        }
+        return folder;
+    }
+    public Folder getFolderWithChildren(User user, Long folderId) {
+        // Children만 left join으로 가져옴
+        log.info("getFolder request: {}", folderId);
+        Folder folder = folderRepository.findByIdWithChildren(folderId)
+                .orElseThrow(() -> new IllegalArgumentException("Folder not found"));
+        if(!folder.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("You do not have permission to access this folder");
+        }
+        return folder;
+    }
+
+
+    @Transactional
+    public void moveFolder(User user, Long folderId, Long targetParentId) {
+        log.info("moveFolder request: {}", folderId);
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new IllegalArgumentException("Folder not found"));
+        if(!folder.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("You do not have permission to move this folder");
+        }
+
+
+        Folder targetParent = folderRepository.findById(targetParentId)
+                .orElseThrow(() -> new IllegalArgumentException("Target parent folder not found"));
+        if(!targetParent.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("You do not have permission to move this folder");
+        }
+
+        if(isCircularMove(folder, targetParent)) {
+            throw new IllegalArgumentException("Cannot move folder to a child folder");
+        }
+
+        folder.setParent(targetParent);
+    }
+
+
+    private boolean isCircularMove(Folder folder, Folder newParent) {
+        Folder current = newParent;
+        while (current != null) {
+            if (current.getId().equals(folder.getId())) return true;
+            current = current.getParent();
+        }
+        return false;
+    }
+
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
@@ -7,13 +7,12 @@ import gnu.capstone.G_Learn_E.domain.folder.repository.FolderRepository;
 import gnu.capstone.G_Learn_E.domain.folder.repository.FolderWorkbookMapRepository;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -78,7 +77,7 @@ public class FolderService {
         return folder;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Folder> getFolderTree(User user) {
         log.info("getFolderTree request");
         return folderRepository.findAllByUserWithParent(user);

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -128,6 +129,13 @@ public class FolderService {
                 .orElseThrow(() -> new IllegalArgumentException("Folder not found"));
         if(!folder.getUser().getId().equals(user.getId())) {
             throw new IllegalArgumentException("You do not have permission to delete this folder");
+        }
+
+        Folder root = getRootFolder(user);
+
+        // 루트 폴더 삭제 불가
+        if (folder.getId().equals(root.getId())) {
+            throw new IllegalStateException("루트 폴더는 삭제할 수 없습니다.");
         }
 
         // 하위 폴더 존재 검사

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -8,6 +8,7 @@ import gnu.capstone.G_Learn_E.global.common.serialization.Option;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ProblemConverter {
 
@@ -88,6 +89,7 @@ public class ProblemConverter {
         if (optionsList == null) {
             return null;
         }
+
         return IntStream.range(0, optionsList.size())
                 .mapToObj(i -> Option.builder()
                         .number((short) (i + 1)) // 1부터 시작하는 번호

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -44,6 +44,9 @@ public class Workbook {
     @Column
     private LocalDateTime createdAt;
 
+    @Column
+    private boolean isUploaded;
+
     @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FolderWorkbookMap> folderWorkbookMaps = new ArrayList<>();
 
@@ -70,5 +73,6 @@ public class Workbook {
         this.courseYear = courseYear;
         this.semester = semester;
         this.createdAt = LocalDateTime.now();
+        this.isUploaded = false;
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -14,6 +14,7 @@ import gnu.capstone.G_Learn_E.domain.workbook.enums.Semester;
 import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -58,10 +59,17 @@ public class WorkbookService {
 
 
     public List<Workbook> getChildrenWorkbooks(Folder folder) {
-        // left join으로 들고오지 못한 FolderWorkbookMap을 가져오기
-        List<FolderWorkbookMap> byFolder = folderWorkbookMapRepository.findByFolderWithWorkbook(folder);
-        return byFolder.stream()
-                .map(FolderWorkbookMap::getWorkbook)
-                .toList();
+        if (Hibernate.isInitialized(folder.getFolderWorkbookMaps())) {
+            // folder workbook이 초기화 된 경우
+            return folder.getFolderWorkbookMaps().stream()
+                    .map(FolderWorkbookMap::getWorkbook)
+                    .toList();
+        } else {
+            // folder workbook이 초기화 되지 않은 경우
+            return folderWorkbookMapRepository.findByFolderWithWorkbook(folder)
+                    .stream()
+                    .map(FolderWorkbookMap::getWorkbook)
+                    .toList();
+        }
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -53,5 +54,14 @@ public class WorkbookService {
         folderWorkbookMapRepository.save(folderWorkbookMap);
 
         return newWorkbook;
+    }
+
+
+    public List<Workbook> getChildrenWorkbooks(Folder folder) {
+        // left join으로 들고오지 못한 FolderWorkbookMap을 가져오기
+        List<FolderWorkbookMap> byFolder = folderWorkbookMapRepository.findByFolderWithWorkbook(folder);
+        return byFolder.stream()
+                .map(FolderWorkbookMap::getWorkbook)
+                .toList();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number  
<!--- ex) #이슈번호 -->  
#38

## 📝 요약(Summary)  
개인 폴더링 시스템 기능 개발 완료: 폴더 생성, 조회, 트리 구조 조회, 이름 변경, 이동, 삭제 기능과 문제집 폴더 내 삭제 기능을 구현하였습니다.

## 🛠️ PR 유형  
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가  
- [x] 코드 리팩토링  
- [x] 주석 추가 및 수정

## 📝 상세 설명(Details)  
- **폴더 CRUD API 개발**  
  - 폴더 생성 (`POST /api/folder`)  
  - 폴더 단일 조회 (`GET /api/folder/{id}`)  
  - 폴더 트리 조회 (`GET /api/folder/folder-tree`)  
  - 폴더 이름 변경 (`PATCH /api/folder/{id}/rename`)  
  - 폴더 이동 (`PATCH /api/folder/{id}/move`)  
  - 폴더 삭제 (`DELETE /api/folder/{id}`)  

- **문제집 폴더 내 삭제 API 개발**  
  - `DELETE /api/folder/{folderId}/workbook/{workbookId}`  
  - 문제집이 public에 업로드 된 경우, response로 isUploaded를 true로 반환

- **제약 조건 추가**  
  - 루트 폴더 삭제 불가  
  - 하위 폴더가 있거나 문제집이 있는 경우 삭제 불가  
  - 순환 참조 방지를 위한 폴더 이동 제약  

- **응답 구조 설계 및 DTO 분리**  
  - `FolderResponse`, `FolderTreeResponse`, `SimpleFolderResponse` 등 다수의 응답 DTO 도입  

- **서비스 계층 로직 정비**  
  - LAZY / FETCH 전략을 고려한 폴더/문제집 조회  
  - 사용자 검증 및 예외 처리 강화

## 📸스크린샷 (선택)  
(생략)

## 💬 공유사항 to 리뷰어  
- 폴더 이동 시 순환 참조 방지 로직(`isCircularMove`)이 잘 동작하는지 리뷰 부탁드립니다.  
- 폴더 트리 조회 로직(`getFolderTree`)에서 성능 개선 여지가 있는지 확인 부탁드립니다.  
- 기타 네이밍이나 구조적으로 개선할 수 있는 부분 있으면 자유롭게 코멘트 주세요!