### PR TITLE
[Feat #41] 생성된 문제집 문제 조회 API

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/ProblemController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/ProblemController.java
@@ -1,10 +1,27 @@
 package gnu.capstone.G_Learn_E.domain.problem.controller;
 
+import gnu.capstone.G_Learn_E.domain.problem.converter.ProblemConverter;
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemSolvePageResponse;
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -13,6 +30,34 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProblemController {
 
     private final ProblemService problemService;
+    private final WorkbookService workbookService;
+    private final SolveLogService solveLogService;
 
-    // TODO : 문제 컨트롤러 구현
+
+    @GetMapping("/workbook/{workbookId}")
+    public ApiResponse<ProblemSolvePageResponse> problemSolvePageLoad(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId
+    ){
+        Workbook workbook = workbookService.findWorkbookById(workbookId);
+        log.info("문제집 조회 성공 : {}", workbook);
+
+        List<Problem> problems = problemService.findAllByWorkbookId(workbook);
+        log.info("문제 조회 성공 : {}", problems);
+
+        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+        log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
+
+        Map<Long, SolveLog> solveLogToMap = solveLogService.findAllSolveLogToMap(solvedWorkbook);
+        log.info("문제 풀이 기록 조회 성공 : {}", solveLogToMap);
+
+        ProblemSolvePageResponse response = ProblemConverter.convertToProblemSolvePageResponse(
+                workbook,
+                problems,
+                solvedWorkbook,
+                solveLogToMap
+        );
+        log.info("문제 풀이 페이지 로드 성공 : {}", response);
+        return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -1,15 +1,26 @@
 package gnu.capstone.G_Learn_E.domain.problem.converter;
 
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemResponse;
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemSolvePageResponse;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.global.common.serialization.Option;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+@Slf4j
 public class ProblemConverter {
 
     /**
@@ -18,7 +29,7 @@ public class ProblemConverter {
      * @return 변환된 Problem 엔티티
      */
     public static Problem convertToMultipleProblem(
-            ProblemGenerateResponse.MultipleChoice mc, Integer problemNumber) {
+            ProblemGenerateResponse.MultipleChoice mc, Integer problemNumber, Workbook workbook) {
         return Problem.builder()
                 .problemNumber(problemNumber)
                 .title(mc.question())
@@ -26,6 +37,7 @@ public class ProblemConverter {
                 .answers(Collections.singletonList(mc.answer()))
                 .explanation(mc.explanation())
                 .type(ProblemType.MULTIPLE)
+                .workbook(workbook)
                 .build();
     }
 
@@ -35,7 +47,8 @@ public class ProblemConverter {
      * @param ox OX 문제 DTO
      * @return 변환된 Problem 엔티티
      */
-    public static Problem convertToOxProblem(ProblemGenerateResponse.Ox ox, Integer problemNumber) {
+    public static Problem convertToOxProblem(
+            ProblemGenerateResponse.Ox ox, Integer problemNumber, Workbook workbook) {
         return Problem.builder()
                 .problemNumber(problemNumber)
                 .title(ox.question())
@@ -43,6 +56,7 @@ public class ProblemConverter {
                 .answers(Collections.singletonList(ox.answer()))
                 .explanation(ox.explanation())
                 .type(ProblemType.OX)
+                .workbook(workbook)
                 .build();
     }
 
@@ -51,7 +65,8 @@ public class ProblemConverter {
      * @param fib 빈칸 채우기 문제 DTO
      * @return 변환된 Problem 엔티티
      */
-    public static Problem convertToBlankProblem(ProblemGenerateResponse.FillInTheBlank fib, Integer problemNumber) {
+    public static Problem convertToBlankProblem(
+            ProblemGenerateResponse.FillInTheBlank fib, Integer problemNumber, Workbook workbook) {
         return Problem.builder()
                 .problemNumber(problemNumber)
                 .title(fib.question())
@@ -59,6 +74,7 @@ public class ProblemConverter {
                 .answers(fib.answer())
                 .explanation(fib.explanation())
                 .type(ProblemType.BLANK)
+                .workbook(workbook)
                 .build();
     }
 
@@ -67,7 +83,8 @@ public class ProblemConverter {
      * @param desc 서술형 문제 DTO
      * @return 변환된 Problem 엔티티
      */
-    public static Problem convertToDescriptiveProblem(ProblemGenerateResponse.Descriptive desc, Integer problemNumber) {
+    public static Problem convertToDescriptiveProblem(
+            ProblemGenerateResponse.Descriptive desc, Integer problemNumber, Workbook workbook) {
         return Problem.builder()
                 .problemNumber(problemNumber)
                 .title(desc.question())
@@ -76,6 +93,7 @@ public class ProblemConverter {
                 // 서술형 문제는 해설이 없는 경우도 있음
                 .explanation(null)
                 .type(ProblemType.DESCRIPTIVE)
+                .workbook(workbook)
                 .build();
     }
 
@@ -96,5 +114,67 @@ public class ProblemConverter {
                         .content(optionsList.get(i))
                         .build())
                 .collect(Collectors.toList());
+    }
+
+
+
+    public static ProblemSolvePageResponse convertToProblemSolvePageResponse(
+            Workbook workbook,
+            List<Problem> problems,
+            SolvedWorkbook solvedWorkbook,
+            Map<Long, SolveLog> solveLogToMap
+    ) {
+        boolean isSolved = solvedWorkbook.getStatus().equals(SolvingStatus.COMPLETED);
+        AtomicInteger correctCount = new AtomicInteger();
+        AtomicInteger wrongCount = new AtomicInteger();
+
+        // 문제 정보와 문제 풀이 기록을 매핑하여 dto로 변환
+        List<ProblemSolvePageResponse.ProblemInfo> problemInfoList =
+                problems.stream()
+                        .sorted(Comparator.comparing(Problem::getProblemNumber)) // 문제 번호로 정렬
+                        .map(problem -> {
+                            // 문제집의 문제 순회
+
+                            // 문제 풀이 기록 매핑
+                            SolveLog solveLog = solveLogToMap.get(problem.getId());
+                            if (isSolved && solveLog.getIsCorrect()) { // 풀이가 완료된 경우
+                                correctCount.getAndIncrement(); // 정답 개수 증가
+                            } else if(isSolved) {
+                                wrongCount.getAndIncrement(); // 오답 개수 증가
+                            }
+
+                            // 문제 정보 변환
+                            ProblemResponse problemResponse = ProblemResponse.from(problem);
+
+                            // 문제 풀이 정보 변환
+                            ProblemSolvePageResponse.ProblemInfo.UserAttempt userAttempt =
+                                    ProblemSolvePageResponse.ProblemInfo.UserAttempt.of(
+                                            (isSolved) ? solveLog.getSubmitAnswer() : null,
+                                            (isSolved) ? solveLog.getIsCorrect() : null
+                                    );
+
+                            // 문제 정보와 풀이 정보를 결합하여 반환
+                            return ProblemSolvePageResponse.ProblemInfo.from(
+                                    problemResponse,
+                                    userAttempt
+                            );
+                        })
+                        .toList();
+
+        for(ProblemSolvePageResponse.ProblemInfo problemInfo : problemInfoList) {
+            log.info("문제 정보 : {}", problemInfo.problem());
+        }
+
+
+        return ProblemSolvePageResponse.from(
+                ProblemSolvePageResponse.WorkbookInfo.of(
+                        workbook.getId(),
+                        workbook.getName(),
+                        isSolved,
+                        (isSolved) ? correctCount.get() : null,
+                        (isSolved) ? wrongCount.get() : null
+                ),
+                problemInfoList
+        );
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemResponse.java
@@ -15,7 +15,7 @@ public record ProblemResponse(
         List<String> answers, // 정답 리스트 (빈칸 복수, 나머지 단일)
         String explanation // 해설
 ) {
-    public static ProblemResponse of(
+    public static ProblemResponse from(
             Long id,
             Integer problemNumber,
             String type,
@@ -27,8 +27,8 @@ public record ProblemResponse(
         return new ProblemResponse(id, problemNumber, type, title, options, answers, explanation);
     }
 
-    public static ProblemResponse of(Problem problem) {
-        return of(
+    public static ProblemResponse from(Problem problem) {
+        return from(
                 problem.getId(),
                 problem.getProblemNumber(),
                 problem.getType().name(),
@@ -39,9 +39,9 @@ public record ProblemResponse(
         );
     }
 
-    public static List<ProblemResponse> of(List<Problem> problems) {
+    public static List<ProblemResponse> from(List<Problem> problems) {
         return problems.stream()
-                .map(ProblemResponse::of)
+                .map(ProblemResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemSolvePageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemSolvePageResponse.java
@@ -1,0 +1,63 @@
+package gnu.capstone.G_Learn_E.domain.problem.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record ProblemSolvePageResponse(
+        @JsonProperty("workbook") WorkbookInfo workbook,
+        @JsonProperty("problems")List<ProblemInfo> problems
+) {
+
+    public static ProblemSolvePageResponse from(
+            WorkbookInfo workbookInfo,
+            List<ProblemInfo> problems
+    ) {
+        return new ProblemSolvePageResponse(workbookInfo, problems);
+    }
+
+    public record WorkbookInfo(
+            Long id,
+            String name,
+            boolean isSolved,
+            Integer correctCount,
+            Integer wrongCount
+    ){
+        public static WorkbookInfo of(
+                Long id,
+                String name,
+                boolean isSolved,
+                Integer correctCount,
+                Integer wrongCount
+        ) {
+            return new WorkbookInfo(id, name, isSolved, correctCount, wrongCount);
+        }
+
+    }
+
+    public record ProblemInfo(
+        ProblemResponse problem,
+        UserAttempt userAttepmt
+    ){
+        public static ProblemInfo from(
+                ProblemResponse problem,
+                UserAttempt userAttepmt
+        ) {
+            return new ProblemInfo(problem, userAttepmt);
+        }
+
+        public record UserAttempt(
+                List<String> submitAnswer,
+                Boolean isCorrect
+        ){
+            public static UserAttempt of(
+                    List<String> submitAnswer,
+                    Boolean isCorrect
+            ) {
+                return new UserAttempt(submitAnswer, isCorrect);
+            }
+        }
+    }
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
@@ -50,12 +50,13 @@ public class Problem {
 
     @Builder
     public Problem(Integer problemNumber, String title, List<Option> options, List<String> answers,
-                   String explanation, ProblemType type) {
+                   String explanation, ProblemType type, Workbook workbook) {
         this.problemNumber = problemNumber;
         this.title = title;
         this.options = options;
         this.answers = answers;
         this.explanation = explanation;
         this.type = type;
+        this.workbook = workbook;
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
@@ -4,6 +4,10 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
+
+    List<Problem> findAllByWorkbookId(Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemService.java
@@ -1,9 +1,13 @@
 package gnu.capstone.G_Learn_E.domain.problem.service;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -12,5 +16,8 @@ public class ProblemService {
 
     private final ProblemRepository problemRepository;
 
-    // TODO : 문제 서비스 구현
+
+    public List<Problem> findAllByWorkbookId(Workbook workbook) {
+        return problemRepository.findAllByWorkbookId(workbook.getId());
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/response/SolveLogResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/response/SolveLogResponse.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.domain.solve_log.dto.response;
+
+public record SolveLogResponse(
+
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolveLog.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolveLog.java
@@ -3,10 +3,12 @@ package gnu.capstone.G_Learn_E.domain.solve_log.entity;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.global.common.serialization.converter.AnswerListConverter;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -22,7 +24,8 @@ public class SolveLog {
     @Column(columnDefinition = "TEXT")
     private List<String> submitAnswer; // 제출한 답안
 
-    boolean isCorrect; // 정답 여부
+    @Column(nullable = true)
+    Boolean isCorrect; // 정답 여부
 
     private LocalDateTime createdAt; // 생성일시
 
@@ -37,4 +40,18 @@ public class SolveLog {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id")
     private Problem problem; // 푼 문제
+
+
+    @Builder
+    public SolveLog(SolvedWorkbook solvedWorkbook, Problem problem){
+        this.isCorrect = null;
+        this.submitAnswer = new ArrayList<>();
+        this.solvedWorkbook = solvedWorkbook;
+        this.problem = problem;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getProblemId() {
+        return this.problem.getId();
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbook.java
@@ -1,8 +1,10 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.entity;
 
+import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +29,15 @@ public class SolvedWorkbook {
 
     @OneToMany(mappedBy = "solvedWorkbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolveLog> solveLogs;
+
+    @Enumerated(EnumType.STRING)
+    private SolvingStatus status; // 풀이 상태 (진행 중, 완료 등)
+
+    @Builder
+    public SolvedWorkbook(SolvedWorkbookId id, User user, Workbook workbook) {
+        this.id = id;
+        this.user = user;
+        this.workbook = workbook;
+        this.status = SolvingStatus.NOT_STARTED;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbookId.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbookId.java
@@ -1,14 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.entity;
 
 import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 
 @Getter
+@Setter
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/enums/SolvingStatus.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/enums/SolvingStatus.java
@@ -1,0 +1,8 @@
+package gnu.capstone.G_Learn_E.domain.solve_log.enums;
+
+public enum SolvingStatus {
+
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolveLogRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolveLogRepository.java
@@ -1,9 +1,14 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.repository;
 
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SolveLogRepository extends JpaRepository<SolveLog, Long> {
+
+    List<SolveLog> findAllBySolvedWorkbookId(SolvedWorkbookId solvedWorkbook_id);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
@@ -1,9 +1,10 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.repository;
 
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SolvedWorkbookRepository extends JpaRepository<SolvedWorkbook, Long> {
+public interface SolvedWorkbookRepository extends JpaRepository<SolvedWorkbook, SolvedWorkbookId> {
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -1,18 +1,79 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.service;
 
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
 import gnu.capstone.G_Learn_E.domain.solve_log.repository.SolveLogRepository;
 import gnu.capstone.G_Learn_E.domain.solve_log.repository.SolvedWorkbookRepository;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SolveLogService {
 
+    private final ProblemRepository problemRepository;
     private final SolveLogRepository solveLogRepository;
     private final SolvedWorkbookRepository solvedWorkbookRepository;
 
     // TODO : 풀이 로그 서비스 구현
+
+    @Transactional
+    public SolvedWorkbook findSolvedWorkbook(Workbook workbook, User user) {
+        SolvedWorkbookId solvedWorkbookId = new SolvedWorkbookId(user.getId(), workbook.getId());
+        log.info("solvedWorkbookId : {}", solvedWorkbookId);
+
+        return solvedWorkbookRepository.findById(solvedWorkbookId).orElseGet(
+                () -> createSolveLogs(workbook, user) // solvedWorkbookId가 없으면 createSolveLogs 메서드 호출
+        );
+    }
+
+    public List<SolveLog> findAllSolveLog(SolvedWorkbook solvedWorkbook) {
+        return solveLogRepository.findAllBySolvedWorkbookId(solvedWorkbook.getId());
+    }
+
+    public Map<Long, SolveLog> findAllSolveLogToMap(SolvedWorkbook solvedWorkbook) {
+        return solveLogRepository.findAllBySolvedWorkbookId(solvedWorkbook.getId())
+                .stream()
+                .collect(Collectors.toMap(SolveLog::getProblemId, Function.identity()));
+    }
+
+    @Transactional
+    public SolvedWorkbook createSolveLogs(Workbook workbook, User user) {
+        SolvedWorkbookId solvedWorkbookId = new SolvedWorkbookId(user.getId(), workbook.getId());
+
+        SolvedWorkbook solvedWorkbook = solvedWorkbookRepository.findById(solvedWorkbookId)
+                .orElseGet(() -> solvedWorkbookRepository.save(
+                        SolvedWorkbook.builder()
+                                .id(solvedWorkbookId)
+                                .user(user)
+                                .workbook(workbook)
+                                .build()
+                ));
+        log.info("solvedWorkbook : {}", solvedWorkbook);
+
+
+        problemRepository.findAllByWorkbookId(workbook.getId()).forEach(problem -> {
+            SolveLog solveLog = SolveLog.builder()
+                    .solvedWorkbook(solvedWorkbook)
+                    .problem(problem)
+                    .build();
+            solveLogRepository.save(solveLog);
+        });
+        log.info("solveLog : {}", solveLogRepository.findAllBySolvedWorkbookId(solvedWorkbook.getId()));
+
+        return solvedWorkbook;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/converter/WorkbookConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/converter/WorkbookConverter.java
@@ -25,25 +25,25 @@ public class WorkbookConverter {
 
         // 1. 객관식 문제 변환
         for (ProblemGenerateResponse.MultipleChoice mc : response.result().multipleChoice()) {
-            Problem problem = convertToMultipleProblem(mc, problemNumber++);
+            Problem problem = convertToMultipleProblem(mc, problemNumber++, workbook);
             problems.add(problem);
         }
 
         // 2. OX 문제 변환
         for (ProblemGenerateResponse.Ox ox : response.result().ox()) {
-            Problem problem = convertToOxProblem(ox, problemNumber++);
+            Problem problem = convertToOxProblem(ox, problemNumber++, workbook);
             problems.add(problem);
         }
 
         // 3. 빈칸 채우기 문제 변환
         for (ProblemGenerateResponse.FillInTheBlank fib : response.result().fillInTheBlank()) {
-            Problem problem = convertToBlankProblem(fib, problemNumber++);
+            Problem problem = convertToBlankProblem(fib, problemNumber++, workbook);
             problems.add(problem);
         }
 
         // 4. 서술형 문제 변환
         for (ProblemGenerateResponse.Descriptive desc : response.result().descriptive()) {
-            Problem problem = convertToDescriptiveProblem(desc, problemNumber++);
+            Problem problem = convertToDescriptiveProblem(desc, problemNumber++, workbook);
             problems.add(problem);
         }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookResponse.java
@@ -37,7 +37,7 @@ public record WorkbookResponse(
                 workbook.getCourseYear(),
                 workbook.getSemester().name(),
                 workbook.getCreatedAt().toString(),
-                ProblemResponse.of(workbook.getProblems())
+                ProblemResponse.from(workbook.getProblems())
         );
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -30,6 +30,12 @@ public class WorkbookService {
     private final FolderWorkbookMapRepository folderWorkbookMapRepository;
 
 
+    public Workbook findWorkbookById(Long workbookId) {
+        return workbookRepository.findById(workbookId)
+                .orElseThrow(() -> new RuntimeException("Workbook not found"));
+    }
+
+
     public Workbook createWorkbook(ProblemGenerateResponse response, User user){
 
         Folder rootFolder = folderRepository.findByUserAndParentIsNull(user)


### PR DESCRIPTION
## #️⃣ Issue Number
#41

## 📝 요약(Summary)
- `ProblemController`: 문제집 내 문제 및 풀이 기록 조회 API(`/api/problem/workbook/{workbookId}`) 구현
- `ProblemConverter`: 문제 유형별 생성 로직에 `Workbook` 매핑 추가 및 `ProblemSolvePageResponse` 변환 메서드 구현
- `ProblemSolvePageResponse`: 문제와 사용자 풀이 기록을 포함하는 DTO 신규 작성
- `SolveLogService`: 사용자의 풀이 기록이 없을 시 자동 생성하는 로직 구현
- `ProblemResponse`: from 방식으로 생성 방식 통일 (`of` → `from`)
- `SolveLog`, `SolvedWorkbook`: 정답 여부, 풀이 상태 등 필드 추가 및 초기화 메서드 구성
- `WorkbookConverter`: 문제 생성 시 `Workbook` 정보 포함하여 `Problem` 생성

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정

## 📝 상세 설명(Details)

1. **문제 조회 API 구현**
   - `GET /api/problem/workbook/{workbookId}` 엔드포인트 추가
   - 인증된 사용자의 문제집 조회 시 문제 목록, 문제 풀이 기록, 정/오답 개수를 포함하여 응답
   - 해당 API는 프론트엔드에서 문제 풀이 페이지 진입 시 사용될 수 있도록 설계됨

2. **문제 변환 로직 개선**
   - 기존 문제 생성 메서드(`convertToMultipleProblem`, 등)에서 `Workbook` 객체를 추가 파라미터로 받아 문제에 연결되도록 수정
   - `convertToProblemSolvePageResponse` 메서드를 통해 문제 목록 + 풀이 상태(정답/오답) 조합 DTO 반환 로직 구현

3. **문제 풀이 응답 DTO 구조화**
   - `ProblemSolvePageResponse` 내부에 문제 정보와 함께 사용자의 시도 정보를 담은 구조 설계 (`ProblemInfo`, `UserAttempt`)
   - `WorkbookInfo`에서는 정답 수, 오답 수, 풀이 여부 등의 정보를 포함하여 한눈에 통계 파악 가능

4. **풀이 기록 자동 생성**
   - 사용자가 해당 문제집에 대한 풀이 기록이 없을 경우 `SolveLogService#createSolveLogs()`에서 자동으로 `SolveLog` 생성
   - `SolvedWorkbook`에 대한 ID 매핑 및 생성 시 `NOT_STARTED` 상태로 초기화됨

5. **기타 리팩토링**
   - `ProblemResponse.of()` → `from()`으로 메서드 네이밍 일관성 개선
   - `ProblemService`, `WorkbookService` 등 유틸성 메서드 추가 (`findWorkbookById`, `findAllByWorkbookId`)
   - DTO 직렬화/역직렬화 편의성을 위해 Jackson 어노테이션 사용

## 📸스크린샷 (선택)
해당 API 응답 예시나 Swagger 문서 스크린샷을 첨부하면 더 도움이 될 수 있습니다.

## 💬 공유사항 to 리뷰어
