### PR TITLE
[Feat #41] 문제 풀이 임시 저장 및 정답 제출 여부 response 개선

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/ProblemController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/ProblemController.java
@@ -15,10 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -149,7 +149,7 @@ public class ProblemConverter {
                             // 문제 풀이 정보 변환
                             ProblemSolvePageResponse.ProblemInfo.UserAttempt userAttempt =
                                     ProblemSolvePageResponse.ProblemInfo.UserAttempt.of(
-                                            (isSolved) ? solveLog.getSubmitAnswer() : null,
+                                            (!solveLog.getSubmitAnswer().isEmpty())? solveLog.getSubmitAnswer() : null,
                                             (isSolved) ? solveLog.getIsCorrect() : null
                                     );
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
@@ -1,10 +1,26 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.controller;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
+import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
+import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SolveLogRequest;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -12,8 +28,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SolveLogController {
 
+    private final WorkbookService workbookService;
+    private final ProblemService problemService;
     private final SolveLogService solveLogService;
 
     // TODO : 풀이 로그 컨트롤러 구현
 
+
+    @PatchMapping("/workbook/{workbookId}")
+    public ApiResponse<?> saveUserAnswer(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId,
+            @RequestBody SaveSolveLogRequest request
+    ){
+        Workbook workbook = workbookService.findWorkbookById(workbookId);
+        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+
+        solveLogService.updateSolveLog(solvedWorkbook, request);
+
+        return new ApiResponse<>(HttpStatus.OK, "풀이 로그 저장 성공", null);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/request/SaveSolveLogRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/request/SaveSolveLogRequest.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.solve_log.dto.request;
+
+
+import java.util.List;
+
+public record SaveSolveLogRequest(
+    List<SolveLogRequest> userAttempts
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/request/SolveLogRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/request/SolveLogRequest.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.solve_log.dto.request;
+
+import java.util.List;
+
+public record SolveLogRequest(
+        Long problemId,
+        List<String> submitAnswer
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolveLog.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolveLog.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ public class SolveLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Convert(converter = AnswerListConverter.class)
     @Column(columnDefinition = "TEXT")
     private List<String> submitAnswer; // 제출한 답안


### PR DESCRIPTION
## #️⃣ Issue Number
#41

## 📝 요약(Summary)
- `SolveLogController`에 사용자의 임시 풀이 로그 저장 API (`PATCH /solve-log/workbook/{workbookId}`)를 추가했습니다.
- 사용자 풀이 기록을 담는 `SaveSolveLogRequest`, `SolveLogRequest` DTO를 새로 생성했습니다.
- `SolveLogService`에 풀이 로그 갱신 로직 (`updateSolveLog`)을 추가했습니다.
- `ProblemConverter`에서 풀이 완료 전 정답 제출 여부도 반영되도록 수정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
1. **SolveLogController에 임시 저장 API 추가**  
   - 사용자가 문제를 풀고 정답을 제출하지 않더라도 중간에 작성한 내용을 임시 저장할 수 있도록 API 엔드포인트를 `PATCH /api/solve-log/workbook/{workbookId}` 경로로 추가했습니다.  
   - `@AuthenticationPrincipal`을 통해 사용자 인증 정보를 받아 해당 워크북과 연관된 풀이 기록을 업데이트합니다.

2. **SaveSolveLogRequest, SolveLogRequest DTO 생성**  
   - 여러 문제에 대한 답안을 한 번에 받기 위해 `List<SolveLogRequest>` 형태의 `SaveSolveLogRequest`를 생성했습니다.  
   - 각 문제별 `problemId`와 사용자가 입력한 `List<String>` 형태의 답안을 담는 `SolveLogRequest`를 정의했습니다.

3. **SolveLogService의 updateSolveLog 구현**  
   - 기존 풀이 기록과 사용자가 새로 제출한 답안을 비교하여, 변경된 경우에만 DB에 반영하는 로직을 구현했습니다.  
   - 불필요한 저장을 방지하고, 순서가 달라졌는지도 함께 고려하여 정확하게 업데이트합니다.

4. **ProblemConverter에서 isSolved 여부와 관계없이 정답 제출 표시하도록 수정**  
   - 기존에는 문제 풀이 상태(`isSolved`)가 완료되어야만 제출한 답안을 사용자에게 보여줬습니다.  
   - 이번 수정으로 풀이 완료가 아니더라도 답안을 제출했다면 해당 내용을 반영해 보여줍니다.

## 📸스크린샷 (선택)
없음

## 💬 공유사항 to 리뷰어
