### PR TITLE
[Refactor #41] 문제 풀이 페이지 API 도메인 변경

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/ProblemController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/ProblemController.java
@@ -1,24 +1,11 @@
 package gnu.capstone.G_Learn_E.domain.problem.controller;
 
-import gnu.capstone.G_Learn_E.domain.problem.converter.ProblemConverter;
-import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemSolvePageResponse;
-import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
-import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
-import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
-import gnu.capstone.G_Learn_E.domain.user.entity.User;
-import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
-import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -31,30 +18,5 @@ public class ProblemController {
     private final SolveLogService solveLogService;
 
 
-    @GetMapping("/workbook/{workbookId}")
-    public ApiResponse<ProblemSolvePageResponse> problemSolvePageLoad(
-            @AuthenticationPrincipal User user,
-            @PathVariable("workbookId") Long workbookId
-    ){
-        Workbook workbook = workbookService.findWorkbookById(workbookId);
-        log.info("문제집 조회 성공 : {}", workbook);
-
-        List<Problem> problems = problemService.findAllByWorkbookId(workbook);
-        log.info("문제 조회 성공 : {}", problems);
-
-        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
-        log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
-
-        Map<Long, SolveLog> solveLogToMap = solveLogService.findAllSolveLogToMap(solvedWorkbook);
-        log.info("문제 풀이 기록 조회 성공 : {}", solveLogToMap);
-
-        ProblemSolvePageResponse response = ProblemConverter.convertToProblemSolvePageResponse(
-                workbook,
-                problems,
-                solvedWorkbook,
-                solveLogToMap
-        );
-        log.info("문제 풀이 페이지 로드 성공 : {}", response);
-        return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
-    }
+    /// TODO : 문제 컨트롤러 구현
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -1,5 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.workbook.controller;
 
+import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.WorkbookSolveResponse;
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.ProblemGenerateRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.WorkbookResponse;
@@ -15,6 +22,9 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/workbook")
@@ -22,6 +32,8 @@ import org.springframework.web.bind.annotation.*;
 public class WorkbookController {
 
     private final WorkbookService workbookService;
+    private final ProblemService problemService;
+    private final SolveLogService solveLogService;
     private final FastApiService fastApiService;
 
     // TODO : 문제집 컨트롤러 구현
@@ -43,5 +55,35 @@ public class WorkbookController {
 
         // Workbook 생성 로직 처리 후 결과 반환
         return new ApiResponse<>(HttpStatus.OK, "문제집 생성에 성공하였습니다.", response);
+    }
+
+    /**
+     * 문제 풀이 페이지 로드
+     */
+    @GetMapping("/{workbookId}/solve")
+    public ApiResponse<WorkbookSolveResponse> problemSolvePageLoad(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId
+    ){
+        Workbook workbook = workbookService.findWorkbookById(workbookId);
+        log.info("문제집 조회 성공 : {}", workbook);
+
+        List<Problem> problems = problemService.findAllByWorkbookId(workbook);
+        log.info("문제 조회 성공 : {}", problems);
+
+        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+        log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
+
+        Map<Long, SolveLog> solveLogToMap = solveLogService.findAllSolveLogToMap(solvedWorkbook);
+        log.info("문제 풀이 기록 조회 성공 : {}", solveLogToMap);
+
+        WorkbookSolveResponse response = WorkbookConverter.convertToWorkbookSolveResponse(
+                workbook,
+                problems,
+                solvedWorkbook,
+                solveLogToMap
+        );
+        log.info("문제 풀이 페이지 로드 성공 : {}", response);
+        return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookSolveResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookSolveResponse.java
@@ -1,20 +1,21 @@
-package gnu.capstone.G_Learn_E.domain.problem.dto.response;
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemResponse;
 
 import java.util.List;
 
-public record ProblemSolvePageResponse(
+public record WorkbookSolveResponse(
         @JsonProperty("workbook") WorkbookInfo workbook,
         @JsonProperty("problems")List<ProblemInfo> problems
 ) {
 
-    public static ProblemSolvePageResponse from(
+    public static WorkbookSolveResponse from(
             WorkbookInfo workbookInfo,
             List<ProblemInfo> problems
     ) {
-        return new ProblemSolvePageResponse(workbookInfo, problems);
+        return new WorkbookSolveResponse(workbookInfo, problems);
     }
 
     public record WorkbookInfo(


### PR DESCRIPTION
## #️⃣ Issue Number
#41

## 📝 요약(Summary)
- 문제 풀이 페이지 로직을 `ProblemController`에서 `WorkbookController`로 이동시켰습니다.
- 기존 `ProblemSolvePageResponse`를 `WorkbookSolveResponse`로 이름 변경 및 경로 이동했습니다.
- `WorkbookConverter`에 문제 풀이 페이지 응답 변환 로직을 이관 및 통합했습니다.
- 관련 로직들을 `WorkbookController`, `WorkbookConverter` 중심으로 리팩토링했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
1. **문제 풀이 페이지 API 도메인 변경**  
   - 기존에 `ProblemController`에 위치하던 문제 풀이 페이지 로드 API(`/api/problem/workbook/{workbookId}`)를 `WorkbookController`로 이동하였고, 새로운 경로는 `/api/workbook/{workbookId}/solve`입니다.  
   - 문제 풀이의 도메인 상 위치가 문제(`Problem`)가 아닌 문제집(`Workbook`)에 더 적합하다고 판단되어 이동 처리하였습니다.

2. **응답 DTO 클래스 및 이름 변경**  
   - 기존 `ProblemSolvePageResponse` 클래스는 `WorkbookSolveResponse`로 변경되었습니다.  
   - 문제풀이와 관련된 데이터 구조도 그에 맞춰 네이밍 수정이 이루어졌습니다.

3. **문제 변환 로직을 WorkbookConverter로 통합**  
   - 문제 리스트 및 풀이 기록을 통합해서 가공하던 로직은 기존에 `ProblemConverter` 내부에 존재했으나, 현재는 `WorkbookConverter.convertToWorkbookSolveResponse`로 이전 및 통합되었습니다.  
   - 이를 통해 기능의 명확한 도메인 소속과 코드 재사용성을 높였습니다.

4. **기존 코드 제거 및 정리**  
   - `ProblemController`에서 문제 풀이 API 메서드 삭제, `ProblemConverter`에서 관련 메서드 제거 등의 코드 정리가 함께 이루어졌습니다.

## 📸스크린샷 (선택)
없음

## 💬 공유사항 to 리뷰어
