### PR TITLE
[Feat #41] 문제 풀이 기록 초기화 API 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
@@ -1,10 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.controller;
 
-import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
-import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
-import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SolveLogRequest;
-import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
@@ -17,10 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -29,10 +21,7 @@ import java.util.Objects;
 public class SolveLogController {
 
     private final WorkbookService workbookService;
-    private final ProblemService problemService;
     private final SolveLogService solveLogService;
-
-    // TODO : 풀이 로그 컨트롤러 구현
 
 
     @PatchMapping("/workbook/{workbookId}")
@@ -47,5 +36,18 @@ public class SolveLogController {
         solveLogService.updateSolveLog(solvedWorkbook, request);
 
         return new ApiResponse<>(HttpStatus.OK, "풀이 로그 저장 성공", null);
+    }
+
+    @DeleteMapping("/workbook/{workbookId}")
+    public ApiResponse<?> deleteUsersSolveLog(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId
+    ){
+        Workbook workbook = workbookService.findWorkbookById(workbookId);
+        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+
+        solveLogService.deleteAllSolveLog(solvedWorkbook);
+
+        return new ApiResponse<>(HttpStatus.OK, "풀이 로그 삭제 성공", null);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -108,4 +108,14 @@ public class SolveLogService {
 
         saveAllSolveLog(logsToUpdate);
     }
+
+    @Transactional
+    public void deleteAllSolveLog(SolvedWorkbook solvedWorkbook) {
+        List<SolveLog> solveLogs = findAllSolveLog(solvedWorkbook);
+        // 문제 별 풀이 로그 삭제
+        solveLogRepository.deleteAll(solveLogs);
+
+        // 문제집 풀이 기록 삭제
+        solvedWorkbookRepository.delete(solvedWorkbook);
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#41

## 📝 요약(Summary)
- 사용자 풀이 기록 전체 삭제를 위한 API(`/api/solve-log/workbook/{workbookId}`)를 `DELETE` 방식으로 추가하였습니다.
- `SolveLogService`에 문제 풀이 로그 및 문제집 풀이 상태를 초기화하는 `deleteAllSolveLog` 메서드를 구현했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
1. **풀이 기록 초기화 API 추가**  
   - 사용자가 특정 문제집의 풀이를 완전히 초기화할 수 있도록 `DELETE /api/solve-log/workbook/{workbookId}` API를 추가했습니다.  
   - 요청 시, 해당 워크북에 대한 사용자의 풀이 기록(`SolveLog`)과 전체 문제집 풀이 상태(`SolvedWorkbook`)가 모두 삭제됩니다.

2. **SolveLogService에 초기화 로직 구현**  
   - `deleteAllSolveLog(SolvedWorkbook solvedWorkbook)` 메서드를 새로 정의하여,  
     (1) 워크북에 대한 개별 문제 풀이 로그들을 삭제하고  
     (2) 최종적으로 문제집 단위의 풀이 상태 객체도 삭제합니다.  
   - 트랜잭션 처리를 통해 안정적으로 전체 초기화가 수행되도록 구성했습니다.

## 📸스크린샷 (선택)
없음

## 💬 공유사항 to 리뷰어
- 향후 특정 문제만 선택적으로 초기화하는 기능도 고려할 수 있을지, 현재 구조로 확장이 용이한지 검토 부탁드립니다.
- 삭제 시의 사용자 경험(예: "정말 초기화하시겠습니까?" 같은 프론트 경고창 등)도 함께 고려되면 좋겠습니다.
