### PR TITLE
[Feat #41] 문제 풀이 채점 API 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolveLog.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolveLog.java
@@ -26,7 +26,7 @@ public class SolveLog {
     @Column(columnDefinition = "TEXT")
     private List<String> submitAnswer; // 제출한 답안
 
-    @Column(nullable = true)
+    @Setter
     Boolean isCorrect; // 정답 여부
 
     private LocalDateTime createdAt; // 생성일시

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbook.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -30,6 +31,7 @@ public class SolvedWorkbook {
     @OneToMany(mappedBy = "solvedWorkbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolveLog> solveLogs;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private SolvingStatus status; // 풀이 상태 (진행 중, 완료 등)
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -1,21 +1,32 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.service;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
+import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
 import gnu.capstone.G_Learn_E.domain.solve_log.repository.SolveLogRepository;
 import gnu.capstone.G_Learn_E.domain.solve_log.repository.SolvedWorkbookRepository;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.response.GradeWorkbookResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeBlankRequest;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeDescriptiveRequest;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.response.GradeBlankResponse;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.response.GradeDescriptiveResponse;
+import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,6 +38,7 @@ public class SolveLogService {
     private final ProblemRepository problemRepository;
     private final SolveLogRepository solveLogRepository;
     private final SolvedWorkbookRepository solvedWorkbookRepository;
+    private final FastApiService fastApiService;
 
     // TODO : 풀이 로그 서비스 구현
 
@@ -78,9 +90,9 @@ public class SolveLogService {
     }
 
     @Transactional
-    public void saveAllSolveLog(List<SolveLog> solveLogs) {
+    public List<SolveLog> saveAllSolveLog(List<SolveLog> solveLogs) {
         // 문제 풀이 로그 저장
-        solveLogRepository.saveAll(solveLogs);
+        return solveLogRepository.saveAll(solveLogs);
     }
 
     @Transactional
@@ -117,5 +129,139 @@ public class SolveLogService {
 
         // 문제집 풀이 기록 삭제
         solvedWorkbookRepository.delete(solvedWorkbook);
+    }
+
+
+    @Transactional
+    public GradeWorkbookResponse gradeAllSolveLog(User user, Workbook workbook, Map<Long, Problem> problemMap) {
+        SolvedWorkbook solvedWorkbook = findSolvedWorkbook(workbook, user);
+
+        // 문제집 풀이 상태 업데이트 (진행 중)
+        // 서술형, 빈칸 등의 채점은 GPT 이용으로 인해 시간이 걸릴 수 있으므로 Flush
+        solvedWorkbook.setStatus(SolvingStatus.IN_PROGRESS);
+        solvedWorkbookRepository.save(solvedWorkbook);
+        solvedWorkbookRepository.flush();
+        try {
+            List<SolveLog> solveLogs = findAllSolveLog(solvedWorkbook);
+            Map<Long, SolveLog> blankSolveLogMap = new HashMap<>();
+            Map<Long, SolveLog> descriptionSolveLogMap = new HashMap<>();
+
+            for (SolveLog solveLog : solveLogs) {
+                Problem problem = problemMap.get(solveLog.getProblemId());
+                if (problem == null) continue;
+
+                if (problem.getType().equals(ProblemType.BLANK)) {
+                    blankSolveLogMap.put(solveLog.getId(), solveLog);
+                } else if (problem.getType().equals(ProblemType.DESCRIPTIVE)) {
+                    descriptionSolveLogMap.put(solveLog.getId(), solveLog);
+                } else {
+                    // 객관식, OX 문제 채점
+                    if (Objects.equals(solveLog.getSubmitAnswer(), problem.getAnswers())) {
+                        solveLog.setIsCorrect(true);
+                        log.info("문제 id : {}, 정답 : {}, 채점 결과 : {}", problem.getId(), problem.getAnswers(), solveLog.getIsCorrect());
+                    } else {
+                        solveLog.setIsCorrect(false);
+                        log.info("문제 id : {}, 정답 : {}, 채점 결과 : {}", problem.getId(), problem.getAnswers(), solveLog.getIsCorrect());
+                    }
+                }
+            }
+
+            // ✅ 병렬로 결과만 먼저 받아옴 (채점 자체는 여기서 수행, 반영은 아래서)
+            log.info("빈칸 채점 비동기 처리 시작");
+            CompletableFuture<List<GradeBlankResponse.GradedProblem>> blankFuture =
+                    CompletableFuture.supplyAsync(() -> gradeBlankProblems(problemMap, blankSolveLogMap))
+                            .exceptionally(e -> {
+                                throw new RuntimeException("빈칸 채점 실패", e);
+                            });
+            log.info("서술형 채점 비동기 처리 시작");
+            CompletableFuture<List<GradeDescriptiveResponse.GradedProblem>> descFuture =
+                    CompletableFuture.supplyAsync(() -> gradeDescriptionProblems(problemMap, descriptionSolveLogMap))
+                            .exceptionally(e -> {
+                                throw new RuntimeException("서술형 채점 실패", e);
+                            });
+
+            List<GradeBlankResponse.GradedProblem> blankResults = blankFuture.join();
+            List<GradeDescriptiveResponse.GradedProblem> descResults = descFuture.join();
+
+            // ✅ 트랜잭션 안에서 결과 반영
+            log.info("빈칸, 서술형 채점 결과 반영 시작");
+            blankResults.forEach(gradedProblem -> {
+                SolveLog solveLog = blankSolveLogMap.get(gradedProblem.id());
+                if (solveLog == null) {
+                    log.warn("빈칸 문제 풀이 로그 없음 : {}", gradedProblem.id());
+                    throw new RuntimeException("빈칸 문제 풀이 로그 없음");
+                }
+                log.info("문제 id : {}, 채점 결과 : {}", gradedProblem.id(), gradedProblem.correct());
+                solveLog.setIsCorrect(gradedProblem.correct());
+            });
+            descResults.forEach(gradedProblem -> {
+                SolveLog solveLog = descriptionSolveLogMap.get(gradedProblem.id());
+                if (solveLog == null) {
+                    log.warn("서술형 문제 풀이 로그 없음 : {}", gradedProblem.id());
+                    throw new RuntimeException("서술형 문제 풀이 로그 없음");
+                }
+                log.info("문제 id : {}, 채점 결과 : {}", gradedProblem.id(), gradedProblem.correct());
+                solveLog.setIsCorrect(gradedProblem.correct());
+            });
+
+            solveLogs = saveAllSolveLog(solveLogs);
+            // 문제집 풀이 상태 업데이트
+            solvedWorkbook.setStatus(SolvingStatus.COMPLETED);
+            solvedWorkbookRepository.save(solvedWorkbook);
+
+            // 문제 풀이 채점 결과 반환
+            int correctCount = (int) solveLogs.stream()
+                    .filter(SolveLog::getIsCorrect)
+                    .count();
+            int wrongCount = solveLogs.size() - correctCount;
+            return GradeWorkbookResponse.of(correctCount, wrongCount);
+        } catch (Exception e) {
+            log.error("문제 풀이 채점 실패", e);
+            restoreStatus(solvedWorkbook);
+            throw new RuntimeException("문제 풀이 채점 실패", e);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void restoreStatus(SolvedWorkbook workbook) {
+        // 새로운 트랜잭션에서 상태 복구
+        workbook.setStatus(SolvingStatus.NOT_STARTED);
+        solvedWorkbookRepository.save(workbook);
+    }
+
+
+
+    private List<GradeBlankResponse.GradedProblem> gradeBlankProblems(Map<Long, Problem> problemMap, Map<Long, SolveLog> blankSolveLogMap) {
+        GradeBlankRequest request = GradeBlankRequest.of(
+                blankSolveLogMap.values().stream()
+                        .map(solveLog -> {
+                                    Problem problem = problemMap.get(solveLog.getProblemId());
+                                    return GradeBlankRequest.Problem.of(
+                                            solveLog.getId(),
+                                            problem.getTitle(),
+                                            problem.getAnswers(),
+                                            solveLog.getSubmitAnswer()
+                                    );
+                                }
+                        )
+                        .toList());
+        return fastApiService.gradeBlank(request).result();
+    }
+
+    private List<GradeDescriptiveResponse.GradedProblem> gradeDescriptionProblems(Map<Long, Problem> problemMap, Map<Long, SolveLog> descriptionSolveLogMap) {
+        GradeDescriptiveRequest request = GradeDescriptiveRequest.of(
+                descriptionSolveLogMap.values().stream()
+                        .map(solveLog -> {
+                                    Problem problem = problemMap.get(solveLog.getProblemId());
+                                    return GradeDescriptiveRequest.Problem.of(
+                                            solveLog.getId(),
+                                            problem.getTitle(),
+                                            problem.getAnswers().getFirst(),
+                                            solveLog.getSubmitAnswer().getFirst()
+                                    );
+                                }
+                        )
+                        .toList());
+        return fastApiService.gradeDescriptive(request).result();
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -138,9 +138,7 @@ public class SolveLogService {
 
         // 문제집 풀이 상태 업데이트 (진행 중)
         // 서술형, 빈칸 등의 채점은 GPT 이용으로 인해 시간이 걸릴 수 있으므로 Flush
-        solvedWorkbook.setStatus(SolvingStatus.IN_PROGRESS);
-        solvedWorkbookRepository.save(solvedWorkbook);
-        solvedWorkbookRepository.flush();
+        forceSetSolvingStatus(solvedWorkbook, SolvingStatus.IN_PROGRESS);
         try {
             List<SolveLog> solveLogs = findAllSolveLog(solvedWorkbook);
             Map<Long, SolveLog> blankSolveLogMap = new HashMap<>();
@@ -217,15 +215,15 @@ public class SolveLogService {
             return GradeWorkbookResponse.of(correctCount, wrongCount);
         } catch (Exception e) {
             log.error("문제 풀이 채점 실패", e);
-            restoreStatus(solvedWorkbook);
+            forceSetSolvingStatus(solvedWorkbook, SolvingStatus.NOT_STARTED);
             throw new RuntimeException("문제 풀이 채점 실패", e);
         }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void restoreStatus(SolvedWorkbook workbook) {
+    public void forceSetSolvingStatus(SolvedWorkbook workbook, SolvingStatus status) {
         // 새로운 트랜잭션에서 상태 복구
-        workbook.setStatus(SolvingStatus.NOT_STARTED);
+        workbook.setStatus(status);
         solvedWorkbookRepository.save(workbook);
     }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/GradeWorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/GradeWorkbookResponse.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
+
+public record GradeWorkbookResponse(
+        int correctCount,
+        int wrongCount
+) {
+    public static GradeWorkbookResponse of(int correctCount, int wrongCount) {
+        return new GradeWorkbookResponse(correctCount, wrongCount);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -7,9 +7,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
     @Query("SELECT swm.workbook FROM SubjectWorkbookMap swm WHERE swm.subject.id = :subjectId")
     List<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId);
+
+    @Query("SELECT w FROM Workbook w JOIN FETCH w.problems p WHERE w.id = :workbookId")
+    Optional<Workbook> findByIdWithProblems(Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -35,6 +35,11 @@ public class WorkbookService {
                 .orElseThrow(() -> new RuntimeException("Workbook not found"));
     }
 
+    public Workbook findWorkbookByIdWithProblems(Long workbookId) {
+        return workbookRepository.findByIdWithProblems(workbookId)
+                .orElseThrow(() -> new RuntimeException("Workbook not found"));
+    }
+
 
     public Workbook createWorkbook(ProblemGenerateResponse response, User user){
 


### PR DESCRIPTION
## #️⃣ Issue Number
#41

## 📝 요약(Summary)
- 문제집 풀이를 채점하는 API(`/api/workbook/{workbookId}/grade`)를 추가했습니다.
- 객관식, OX는 로컬에서 즉시 채점, 빈칸/서술형 문제는 FastAPI를 활용한 비동기 채점 방식으로 구현했습니다.
- 채점 후 전체 정오답 개수를 포함한 결과(`GradeWorkbookResponse`)를 반환합니다.
- 관련된 서비스 메서드 및 DTO 클래스, 레포지토리 확장을 포함합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
1. **채점 API 엔드포인트 추가**  
   - `POST /api/workbook/{workbookId}/grade`로 사용자가 제출한 풀이 기록을 채점합니다.  
   - 요청 시 먼저 기존 풀이 로그를 갱신하고, 이어서 전체 문제를 채점하는 방식입니다.

2. **SolveLogService 내부 채점 로직 구현**  
   - 객관식, OX 문제는 로컬에서 정답 리스트와 제출 리스트를 직접 비교해 채점합니다.  
   - 빈칸(`BLANK`)과 서술형(`DESCRIPTIVE`)은 각각 FastAPI에 비동기로 요청하여 채점 결과를 받아옵니다.  
   - 모든 채점 결과를 기존 풀이 로그(`SolveLog`)에 반영하고, `SolvedWorkbook`의 상태를 `COMPLETED`로 변경합니다.

3. **GradeWorkbookResponse 응답 DTO 추가**  
   - 채점 결과로 정답 개수와 오답 개수를 담은 `GradeWorkbookResponse`를 반환합니다.

4. **WorkbookRepository, WorkbookService 확장**  
   - 문제집과 함께 문제 리스트를 가져오는 쿼리 메서드(`findByIdWithProblems`) 추가하여 채점 시 활용합니다.

5. **에러 핸들링 및 트랜잭션 복원 처리**  
   - 채점 도중 실패 시 문제집 풀이 상태를 `NOT_STARTED`로 복원하여 일관성 유지합니다.  
   - FastAPI 호출 실패도 명확하게 로그 처리되도록 구성하였습니다.

## 📸스크린샷 (선택)
없음

## 💬 공유사항 to 리뷰어