### PR TITLE
[Refactor #52] 문제, 문제집 N:M 매핑 리팩토링 및 고아 엔티티 정리 기능 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/GLearnEApplication.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/GLearnEApplication.java
@@ -6,9 +6,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 @EnableConfigurationProperties({FastApiProperties.class, SecurityPathProperties.class})
 public class GLearnEApplication {
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -3,10 +3,10 @@ package gnu.capstone.G_Learn_E.domain.problem.converter;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
-import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.global.common.serialization.Option;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,15 +21,13 @@ public class ProblemConverter {
      * @return 변환된 Problem 엔티티
      */
     public static Problem convertToMultipleProblem(
-            ProblemGenerateResponse.MultipleChoice mc, Integer problemNumber, Workbook workbook) {
+            ProblemGenerateResponse.MultipleChoice mc) {
         return Problem.builder()
-                .problemNumber(problemNumber)
                 .title(mc.question())
                 .options(convertOptions(mc.options()))
                 .answers(Collections.singletonList(mc.answer()))
                 .explanation(mc.explanation())
                 .type(ProblemType.MULTIPLE)
-                .workbook(workbook)
                 .build();
     }
 
@@ -40,15 +38,13 @@ public class ProblemConverter {
      * @return 변환된 Problem 엔티티
      */
     public static Problem convertToOxProblem(
-            ProblemGenerateResponse.Ox ox, Integer problemNumber, Workbook workbook) {
+            ProblemGenerateResponse.Ox ox) {
         return Problem.builder()
-                .problemNumber(problemNumber)
                 .title(ox.question())
                 .options(null)
                 .answers(Collections.singletonList(ox.answer()))
                 .explanation(ox.explanation())
                 .type(ProblemType.OX)
-                .workbook(workbook)
                 .build();
     }
 
@@ -58,15 +54,13 @@ public class ProblemConverter {
      * @return 변환된 Problem 엔티티
      */
     public static Problem convertToBlankProblem(
-            ProblemGenerateResponse.FillInTheBlank fib, Integer problemNumber, Workbook workbook) {
+            ProblemGenerateResponse.FillInTheBlank fib) {
         return Problem.builder()
-                .problemNumber(problemNumber)
                 .title(fib.question())
                 .options(null)
                 .answers(fib.answer())
                 .explanation(fib.explanation())
                 .type(ProblemType.BLANK)
-                .workbook(workbook)
                 .build();
     }
 
@@ -76,16 +70,14 @@ public class ProblemConverter {
      * @return 변환된 Problem 엔티티
      */
     public static Problem convertToDescriptiveProblem(
-            ProblemGenerateResponse.Descriptive desc, Integer problemNumber, Workbook workbook) {
+            ProblemGenerateResponse.Descriptive desc) {
         return Problem.builder()
-                .problemNumber(problemNumber)
                 .title(desc.question())
                 .options(null)
                 .answers(Collections.singletonList(desc.answer()))
                 // 서술형 문제는 해설이 없는 경우도 있음
                 .explanation(null)
                 .type(ProblemType.DESCRIPTIVE)
-                .workbook(workbook)
                 .build();
     }
 
@@ -106,5 +98,32 @@ public class ProblemConverter {
                         .content(optionsList.get(i))
                         .build())
                 .collect(Collectors.toList());
+    }
+
+
+    public static List<Problem> convertToProblems(ProblemGenerateResponse response) {
+        List<Problem> result = new ArrayList<>();
+
+        // 1. 객관식 문제 변환
+        for (ProblemGenerateResponse.MultipleChoice mc : response.result().multipleChoice()) {
+            result.add(convertToMultipleProblem(mc));
+        }
+
+        // 2. OX 문제 변환
+        for (ProblemGenerateResponse.Ox ox : response.result().ox()) {
+            result.add(convertToOxProblem(ox));
+        }
+
+        // 3. 빈칸 채우기 문제 변환
+        for (ProblemGenerateResponse.FillInTheBlank fib : response.result().fillInTheBlank()) {
+            result.add(convertToBlankProblem(fib));
+        }
+
+        // 4. 서술형 문제 변환
+        for (ProblemGenerateResponse.Descriptive desc : response.result().descriptive()) {
+            result.add(convertToDescriptiveProblem(desc));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/ProblemResponse.java
@@ -1,46 +1,43 @@
 package gnu.capstone.G_Learn_E.domain.problem.dto.response;
 
-import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.global.common.serialization.Option;
 
+import java.util.Comparator;
 import java.util.List;
 
+
 public record ProblemResponse(
-        Long id, // 문제 ID
-        Integer problemNumber, // 문제 번호
-        String type, // 문제 유형
-        String title, // 문제 제목
-        List<String> options, // 문제 선택지 (객관식 문제에만 해당)
-
-        List<String> answers, // 정답 리스트 (빈칸 복수, 나머지 단일)
-        String explanation // 해설
+        Long id,               // 문제 ID
+        Integer problemNumber, // 매핑테이블에서 가져오는 문제 번호
+        String type,           // 문제 유형
+        String title,          // 문제 제목
+        List<String> options,  // 객관식 보기 (Option.content)
+        List<String> answers,  // 정답 리스트
+        String explanation     // 해설
 ) {
-    public static ProblemResponse from(
-            Long id,
-            Integer problemNumber,
-            String type,
-            String title,
-            List<String> options,
-            List<String> answers,
-            String explanation
-    ) {
-        return new ProblemResponse(id, problemNumber, type, title, options, answers, explanation);
-    }
-
-    public static ProblemResponse from(Problem problem) {
-        return from(
-                problem.getId(),
-                problem.getProblemNumber(),
-                problem.getType().name(),
-                problem.getTitle(),
-                problem.getOptions() != null ? problem.getOptions().stream().map(Option::getContent).toList() : null,
-                problem.getAnswers(),
-                problem.getExplanation()
+    /** 매핑 엔티티로부터 DTO 생성 */
+    public static ProblemResponse from(ProblemWorkbookMap map) {
+        var p = map.getProblem();
+        return new ProblemResponse(
+                p.getId(),
+                map.getProblemNumber(),
+                p.getType().name(),
+                p.getTitle(),
+                p.getOptions() == null
+                        ? List.of()
+                        : p.getOptions().stream()
+                        .map(Option::getContent)
+                        .toList(),
+                p.getAnswers(),
+                p.getExplanation()
         );
     }
 
-    public static List<ProblemResponse> from(List<Problem> problems) {
-        return problems.stream()
+    /** 정렬된 매핑 리스트에서 한 번에 변환 */
+    public static List<ProblemResponse> from(List<ProblemWorkbookMap> maps) {
+        return maps.stream()
+                .sorted(Comparator.comparing(ProblemWorkbookMap::getProblemNumber))
                 .map(ProblemResponse::from)
                 .toList();
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
@@ -1,16 +1,17 @@
 package gnu.capstone.G_Learn_E.domain.problem.entity;
 
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.global.common.serialization.converter.AnswerListConverter;
 import gnu.capstone.G_Learn_E.global.common.serialization.converter.OptionListConverter;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.global.common.serialization.Option;
-import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -20,43 +21,49 @@ public class Problem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // 문제 번호
+    private Long id;
 
-    private Integer problemNumber; // 문제 번호 (문제집 내에서의 순서)
-
-    private String title;        // 문제 제목
+    private String title;
 
     @Convert(converter = OptionListConverter.class)
     @Column(columnDefinition = "TEXT")
-    private List<Option> options; // 객관식 보기, 나머지는 null
+    private List<Option> options;
 
     @Convert(converter = AnswerListConverter.class)
     @Column(columnDefinition = "TEXT")
-    private List<String> answers; // 정답 리스트 (빈칸 복수, 나머지 단일)
+    private List<String> answers;
 
     @Column(columnDefinition = "TEXT")
-    private String explanation;  // 해설
+    private String explanation;
 
     @Enumerated(EnumType.STRING)
-    private ProblemType type;    // 문제 유형 (객관식, OX, 주관식 등)
+    private ProblemType type;
 
+    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProblemWorkbookMap> problemWorkbookMaps = new ArrayList<>();
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "workbook_id")
-    private Workbook workbook;    // 문제가 속한 문제집
-
-    @OneToMany(mappedBy = "problem", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SolveLog> solveLogs; // 문제를 푼 사용자들의 풀이 기록
+    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SolveLog> solveLogs = new ArrayList<>();
 
     @Builder
-    public Problem(Integer problemNumber, String title, List<Option> options, List<String> answers,
-                   String explanation, ProblemType type, Workbook workbook) {
-        this.problemNumber = problemNumber;
+    public Problem(String title,
+                   List<Option> options,
+                   List<String> answers,
+                   String explanation,
+                   ProblemType type) {
         this.title = title;
         this.options = options;
         this.answers = answers;
         this.explanation = explanation;
         this.type = type;
-        this.workbook = workbook;
+    }
+
+    /**
+     * 편의 메서드: 이 문제를 워크북에 매핑합니다.
+     */
+    public void addToWorkbook(Workbook workbook, Integer problemNumber) {
+        ProblemWorkbookMap map = new ProblemWorkbookMap(workbook, this, problemNumber);
+        this.problemWorkbookMaps.add(map);
+        workbook.getProblemWorkbookMaps().add(map);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/ProblemWorkbookMap.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/ProblemWorkbookMap.java
@@ -1,0 +1,40 @@
+package gnu.capstone.G_Learn_E.domain.problem.entity;
+
+
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ProblemWorkbookMap {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;                    // << 단일 PK 로 변경
+
+    @ManyToOne(fetch = LAZY)             // 외래키만 남김
+    @JoinColumn(name = "workbook_id")
+    private Workbook workbook;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+
+    @Column(nullable=false)
+    private Integer problemNumber;
+
+    // 생성자
+    @Builder
+    public ProblemWorkbookMap(Workbook workbook, Problem problem, Integer problemNumber) {
+        this.workbook = workbook;
+        this.problem  = problem;
+        this.problemNumber = problemNumber;
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
@@ -2,9 +2,19 @@ package gnu.capstone.G_Learn_E.domain.problem.repository;
 
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
+
+    /** 어떤 문제집에도 속하지 않는 고아 문제 조회 */
+    @Query("""
+        SELECT p FROM Problem p
+        WHERE p.problemWorkbookMaps IS EMPTY
+    """)
+    List<Problem> findOrphanProblems();
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
@@ -4,10 +4,7 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
-
-    List<Problem> findAllByWorkbookId(Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemWorkbookMapRepository.java
@@ -1,0 +1,18 @@
+package gnu.capstone.G_Learn_E.domain.problem.repository;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProblemWorkbookMapRepository
+        extends JpaRepository<ProblemWorkbookMap, Long> {
+
+    /**
+     * workbook.id 를 기준으로
+     * problemNumber 순 정렬된 매핑 엔티티 리스트를 가져옵니다.
+     */
+    List<ProblemWorkbookMap> findAllByWorkbook_IdOrderByProblemNumber(Long workbookId);
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemService.java
@@ -1,13 +1,10 @@
 package gnu.capstone.G_Learn_E.domain.problem.service;
 
-import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
-import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 
 @Slf4j
 @Service
@@ -17,7 +14,4 @@ public class ProblemService {
     private final ProblemRepository problemRepository;
 
 
-    public List<Problem> findAllByWorkbookId(Workbook workbook) {
-        return problemRepository.findAllByWorkbookId(workbook.getId());
-    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -1,8 +1,10 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.service;
 
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemWorkbookMapRepository;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
@@ -14,11 +16,13 @@ import gnu.capstone.G_Learn_E.domain.solve_log.repository.SolvedWorkbookReposito
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.GradeWorkbookResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeBlankRequest;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeDescriptiveRequest;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.response.GradeBlankResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.response.GradeDescriptiveResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,9 +39,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SolveLogService {
 
-    private final ProblemRepository problemRepository;
+    private final WorkbookRepository workbookRepository;
     private final SolveLogRepository solveLogRepository;
     private final SolvedWorkbookRepository solvedWorkbookRepository;
+    private final ProblemWorkbookMapRepository problemWorkbookMapRepository;
     private final FastApiService fastApiService;
 
     // TODO : 풀이 로그 서비스 구현
@@ -77,10 +82,10 @@ public class SolveLogService {
         log.info("solvedWorkbook : {}", solvedWorkbook);
 
 
-        problemRepository.findAllByWorkbookId(workbook.getId()).forEach(problem -> {
+        problemWorkbookMapRepository.findAllByWorkbook_IdOrderByProblemNumber(workbook.getId()).forEach(problem -> {
             SolveLog solveLog = SolveLog.builder()
                     .solvedWorkbook(solvedWorkbook)
-                    .problem(problem)
+                    .problem(problem.getProblem())
                     .build();
             solveLogRepository.save(solveLog);
         });
@@ -131,11 +136,33 @@ public class SolveLogService {
         solvedWorkbookRepository.delete(solvedWorkbook);
     }
 
-
     @Transactional
-    public GradeWorkbookResponse gradeAllSolveLog(User user, Workbook workbook, Map<Long, Problem> problemMap) {
+    public GradeWorkbookResponse gradeWorkbook(
+            User user,
+            Long workbookId,
+            SaveSolveLogRequest request
+    ) {
+        // 1. Workbook + Problems 한 번에 로드
+        Workbook workbook = workbookRepository.findWithMappingsAndProblemsById(workbookId)
+                .orElseThrow(() -> new EntityNotFoundException("Workbook not found"));
+
+        // 2. SolvedWorkbook 조회 or 신규 생성
         SolvedWorkbook solvedWorkbook = findSolvedWorkbook(workbook, user);
 
+        // 3. 사용자가 보낸 풀이 저장/업데이트
+        updateSolveLog(solvedWorkbook, request);
+
+        // 4. grading: 문제 목록과 정답 맵 생성
+        Map<Long, Problem> problemMap = workbook.getProblemWorkbookMaps().stream()
+                .map(ProblemWorkbookMap::getProblem)
+                .collect(Collectors.toMap(Problem::getId, Function.identity()));
+
+        // 5. 채점 수행
+        return gradeAllSolveLog(solvedWorkbook, problemMap);
+    }
+
+    @Transactional
+    public GradeWorkbookResponse gradeAllSolveLog(SolvedWorkbook solvedWorkbook, Map<Long, Problem> problemMap) {
         // 문제집 풀이 상태 업데이트 (진행 중)
         // 서술형, 빈칸 등의 채점은 GPT 이용으로 인해 시간이 걸릴 수 있으므로 Flush
         forceSetSolvingStatus(solvedWorkbook, SolvingStatus.IN_PROGRESS);

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/converter/WorkbookConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/converter/WorkbookConverter.java
@@ -2,124 +2,68 @@ package gnu.capstone.G_Learn_E.domain.workbook.converter;
 
 import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemResponse;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
-import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.WorkbookSolveResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static gnu.capstone.G_Learn_E.domain.problem.converter.ProblemConverter.*;
 
 @Slf4j
 public class WorkbookConverter {
 
-    /**
-     * ProblemGenerateResponse DTO를 기반으로 Workbook 객체와 해당 Workbook에 포함될 Problem 엔티티들을 생성합니다.
-     *
-     * @param response Problem 생성 DTO
-     * @param workbook 변환 대상 Workbook 엔티티 (기본 정보는 이미 셋팅되어 있다고 가정)
-     * @return 문제들이 추가된 Workbook 객체
-     */
-    public static Workbook convertToWorkbookAndProblems(ProblemGenerateResponse response, Workbook workbook) {
-        List<Problem> problems = new ArrayList<>();
-
-        Integer problemNumber = 1; // 문제 번호 초기화
-
-        // 1. 객관식 문제 변환
-        for (ProblemGenerateResponse.MultipleChoice mc : response.result().multipleChoice()) {
-            Problem problem = convertToMultipleProblem(mc, problemNumber++, workbook);
-            problems.add(problem);
-        }
-
-        // 2. OX 문제 변환
-        for (ProblemGenerateResponse.Ox ox : response.result().ox()) {
-            Problem problem = convertToOxProblem(ox, problemNumber++, workbook);
-            problems.add(problem);
-        }
-
-        // 3. 빈칸 채우기 문제 변환
-        for (ProblemGenerateResponse.FillInTheBlank fib : response.result().fillInTheBlank()) {
-            Problem problem = convertToBlankProblem(fib, problemNumber++, workbook);
-            problems.add(problem);
-        }
-
-        // 4. 서술형 문제 변환
-        for (ProblemGenerateResponse.Descriptive desc : response.result().descriptive()) {
-            Problem problem = convertToDescriptiveProblem(desc, problemNumber++, workbook);
-            problems.add(problem);
-        }
-
-        // Workbook의 문제 목록에 추가 (양방향 연관관계 설정)
-        workbook.getProblems().addAll(problems);
-        return workbook;
-    }
-
 
     public static WorkbookSolveResponse convertToWorkbookSolveResponse(
             Workbook workbook,
-            List<Problem> problems,
             SolvedWorkbook solvedWorkbook,
-            Map<Long, SolveLog> solveLogToMap
+            List<ProblemWorkbookMap> problemWorkbookMaps,
+            Map<Long, SolveLog> solveLogMap
     ) {
-        boolean isSolved = solvedWorkbook.getStatus().equals(SolvingStatus.COMPLETED);
+        boolean isSolved = solvedWorkbook.getStatus() == SolvingStatus.COMPLETED;
         AtomicInteger correctCount = new AtomicInteger();
-        AtomicInteger wrongCount = new AtomicInteger();
+        AtomicInteger wrongCount   = new AtomicInteger();
 
-        // 문제 정보와 문제 풀이 기록을 매핑하여 dto로 변환
-        List<WorkbookSolveResponse.ProblemInfo> problemInfoList =
-                problems.stream()
-                        .sorted(Comparator.comparing(Problem::getProblemNumber)) // 문제 번호로 정렬
-                        .map(problem -> {
-                            // 문제집의 문제 순회
+        // 매핑된 순서(problemNumber) 기준 정렬 후 DTO 변환
+        List<WorkbookSolveResponse.ProblemInfo> problemInfoList = problemWorkbookMaps.stream()
+                .sorted(Comparator.comparing(ProblemWorkbookMap::getProblemNumber))
+                .map(map -> {
+                    Problem problem = map.getProblem();
+                    SolveLog solveLog = solveLogMap.get(problem.getId());
 
-                            // 문제 풀이 기록 매핑
-                            SolveLog solveLog = solveLogToMap.get(problem.getId());
-                            if (isSolved && solveLog.getIsCorrect()) { // 풀이가 완료된 경우
-                                correctCount.getAndIncrement(); // 정답 개수 증가
-                            } else if(isSolved) {
-                                wrongCount.getAndIncrement(); // 오답 개수 증가
-                            }
+                    if (isSolved && Boolean.TRUE.equals(solveLog.getIsCorrect())) {
+                        correctCount.getAndIncrement();
+                    } else if (isSolved) {
+                        wrongCount.getAndIncrement();
+                    }
 
-                            // 문제 정보 변환
-                            ProblemResponse problemResponse = ProblemResponse.from(problem);
-
-                            // 문제 풀이 정보 변환
-                            WorkbookSolveResponse.ProblemInfo.UserAttempt userAttempt =
-                                    WorkbookSolveResponse.ProblemInfo.UserAttempt.of(
-                                            (!solveLog.getSubmitAnswer().isEmpty())? solveLog.getSubmitAnswer() : null,
-                                            (isSolved) ? solveLog.getIsCorrect() : null
-                                    );
-
-                            // 문제 정보와 풀이 정보를 결합하여 반환
-                            return WorkbookSolveResponse.ProblemInfo.from(
-                                    problemResponse,
-                                    userAttempt
+                    ProblemResponse pr = ProblemResponse.from(map);
+                    WorkbookSolveResponse.ProblemInfo.UserAttempt ua =
+                            WorkbookSolveResponse.ProblemInfo.UserAttempt.of(
+                                    !solveLog.getSubmitAnswer().isEmpty() ? solveLog.getSubmitAnswer() : null,
+                                    isSolved ? solveLog.getIsCorrect() : null
                             );
-                        })
-                        .toList();
 
-        for(WorkbookSolveResponse.ProblemInfo problemInfo : problemInfoList) {
-            log.info("문제 정보 : {}", problemInfo.problem());
-        }
-
+                    return WorkbookSolveResponse.ProblemInfo.from(pr, ua);
+                })
+                .toList();
 
         return WorkbookSolveResponse.from(
                 WorkbookSolveResponse.WorkbookInfo.of(
                         workbook.getId(),
                         workbook.getName(),
                         isSolved,
-                        (isSolved) ? correctCount.get() : null,
-                        (isSolved) ? wrongCount.get() : null
+                        isSolved ? correctCount.get() : null,
+                        isSolved ? wrongCount.get() : null
                 ),
                 problemInfoList
         );
     }
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookResponse.java
@@ -40,7 +40,7 @@ public record WorkbookResponse(
                 workbook.getCourseYear(),
                 workbook.getSemester().name(),
                 workbook.getCreatedAt().toString(),
-                ProblemResponse.from(workbook.getProblems())
+                ProblemResponse.from(workbook.getProblemWorkbookMaps())
         );
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -3,6 +3,7 @@ package gnu.capstone.G_Learn_E.domain.workbook.entity;
 import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.Semester;
@@ -39,14 +40,17 @@ public class Workbook {
     private LocalDateTime createdAt;
     private boolean isUploaded;
 
-    @OneToMany(mappedBy = "workbook", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SubjectWorkbookMap> subjectWorkbookMaps = new ArrayList<>();
+
+    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FolderWorkbookMap> folderWorkbookMaps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "workbook", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("problemNumber ASC")
     private List<ProblemWorkbookMap> problemWorkbookMaps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "workbook", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolvedWorkbook> solvedWorkbooks = new ArrayList<>();
 
     @PrePersist

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -1,7 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.workbook.entity;
 
 import gnu.capstone.G_Learn_E.domain.folder.entity.FolderWorkbookMap;
-import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookMap;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
@@ -19,60 +19,67 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class Workbook {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
     private String name;
-
-    @Column
     private String professor;
 
     @Enumerated(EnumType.STRING)
     private ExamType examType;
 
-    @Column
     private Integer coverImage;
-
-    @Column
     private Integer courseYear;
 
     @Enumerated(EnumType.STRING)
     private Semester semester;
 
-    @Column
     private LocalDateTime createdAt;
-
-    @Column
     private boolean isUploaded;
 
-    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "workbook", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FolderWorkbookMap> folderWorkbookMaps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SubjectWorkbookMap> subjectWorkbookMaps = new ArrayList<>();
+    @OneToMany(mappedBy = "workbook", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("problemNumber ASC")
+    private List<ProblemWorkbookMap> problemWorkbookMaps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Problem> problems = new ArrayList<>();
-
-    @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "workbook", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolvedWorkbook> solvedWorkbooks = new ArrayList<>();
 
     @PrePersist
-    public void prePersist(){
+    protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
 
     @Builder
-    public Workbook(String name, String professor, ExamType examType, Integer coverImage, Integer courseYear, Semester semester){
+    public Workbook(String name,
+                    String professor,
+                    ExamType examType,
+                    Integer coverImage,
+                    Integer courseYear,
+                    Semester semester) {
         this.name = name;
         this.professor = professor;
         this.examType = examType;
         this.coverImage = coverImage;
         this.courseYear = courseYear;
         this.semester = semester;
-        this.createdAt = LocalDateTime.now();
         this.isUploaded = false;
+    }
+
+    /**
+     * 문제를 이 워크북에 매핑합니다.
+     */
+    public void addProblem(Problem problem, Integer problemNumber) {
+        ProblemWorkbookMap map = ProblemWorkbookMap.builder()
+                .workbook(this)
+                .problem(problem)
+                .problemNumber(problemNumber)
+                .build();
+        this.problemWorkbookMaps.add(map);
+        problem.getProblemWorkbookMaps().add(map);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -20,4 +20,12 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
             "problemWorkbookMaps.problem"
     })
     Optional<Workbook> findWithMappingsAndProblemsById(@Param("workbookId") Long workbookId);
+
+    /** 폴더·과목 매핑이 모두 없는 고아 워크북 조회 */
+    @Query("""
+        SELECT w FROM Workbook w
+        WHERE w.folderWorkbookMaps IS EMPTY
+          AND w.subjectWorkbookMaps IS EMPTY
+    """)
+    List<Workbook> findOrphanWorkbooks();
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -1,6 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.workbook.repository;
 
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +15,9 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
     @Query("SELECT swm.workbook FROM SubjectWorkbookMap swm WHERE swm.subject.id = :subjectId")
     List<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId);
 
-    @Query("SELECT w FROM Workbook w JOIN FETCH w.problems p WHERE w.id = :workbookId")
-    Optional<Workbook> findByIdWithProblems(Long workbookId);
+    @EntityGraph(attributePaths = {
+            "problemWorkbookMaps",
+            "problemWorkbookMaps.problem"
+    })
+    Optional<Workbook> findWithMappingsAndProblemsById(@Param("workbookId") Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/admin/AdminController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/admin/AdminController.java
@@ -1,0 +1,30 @@
+package gnu.capstone.G_Learn_E.global.admin;
+
+
+import gnu.capstone.G_Learn_E.global.admin.dto.CleanupResult;
+import gnu.capstone.G_Learn_E.global.scheduler.OrphanCleanupScheduler;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final OrphanCleanupScheduler cleanupScheduler;
+
+    /** 관리자 전용 즉시 정리 엔드포인트 */
+    @DeleteMapping("/orphans")
+    public ApiResponse<CleanupResult> triggerCleanup() {
+        CleanupResult result = cleanupScheduler.cleanUpNow();
+        return new ApiResponse<>(
+                HttpStatus.OK,
+                "고아 엔티티 정리 완료",
+                result
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/admin/dto/CleanupResult.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/admin/dto/CleanupResult.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.global.admin.dto;
+
+/** 고아 엔티티 정리 결과 */
+public record CleanupResult(
+        int deletedWorkbooks,
+        int deletedProblems
+) {
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/scheduler/OrphanCleanupScheduler.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/scheduler/OrphanCleanupScheduler.java
@@ -1,0 +1,52 @@
+package gnu.capstone.G_Learn_E.global.scheduler;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
+import gnu.capstone.G_Learn_E.global.admin.dto.CleanupResult;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrphanCleanupScheduler {
+
+    private final WorkbookRepository workbookRepo;
+    private final ProblemRepository  problemRepo;
+
+    /** 스케줄러(새벽 3시)용 */
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void scheduledCleanUp() {
+        CleanupResult result = cleanUpInternal();
+        log.info("스케줄러 실행: 워크북 {}건, 문제 {}건 삭제",
+                result.deletedWorkbooks(), result.deletedProblems());
+    }
+
+    /** API에서 바로 호출할 메서드 */
+    @Transactional
+    public CleanupResult cleanUpNow() {
+        return cleanUpInternal();
+    }
+
+    /** 실제 정리 로직 */
+    private CleanupResult cleanUpInternal() {
+
+        List<Workbook> orphanWb = workbookRepo.findOrphanWorkbooks();
+        int wbCnt = orphanWb.size();
+        if (wbCnt > 0) workbookRepo.deleteAll(orphanWb);
+
+        List<Problem> orphanPb = problemRepo.findOrphanProblems();
+        int pbCnt = orphanPb.size();
+        if (pbCnt > 0) problemRepo.deleteAll(orphanPb);
+
+        return new CleanupResult(wbCnt, pbCnt);
+    }
+}
+


### PR DESCRIPTION
## #️⃣ Issue Number
#52

## 📝 요약(Summary)
- `Problem`과 `Workbook`의 관계를 `ProblemWorkbookMap`을 통한 N:M 매핑으로 리팩토링했습니다.
- 고아 문제(어떤 문제집에도 속하지 않는 문제)와 고아 문제집을 정리하는 스케쥴러 및 관리자 API를 추가했습니다.
- 기존 문제 생성, 조회, 풀이 로직들을 새 매핑 구조에 맞게 수정했습니다.
- 각 도메인(`Problem`, `Workbook`, `SolveLog`, 등) 관련 Repository, Service, Converter 코드들을 리팩토링했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링

## 📝 상세 설명(Details)
1. **Problem-Workbook 매핑 구조 변경**
   - `ProblemWorkbookMap` 엔티티를 도입하여 문제와 문제집 간 다대다(N:M) 관계를 관리합니다.
   - 문제 번호(`problemNumber`)를 매핑 테이블에서 관리하여 문제 재정렬 및 복수 매핑을 가능하게 했습니다.

2. **Orphan Cleanup 기능 추가**
   - 고아 워크북(폴더와 과목에 속하지 않은 워크북)과 고아 문제(어떤 문제집에도 포함되지 않은 문제)를 정리하는 스케쥴러(`OrphanCleanupScheduler`)를 구현했습니다.
   - `/api/admin/orphans` 엔드포인트를 통해 관리자가 즉시 정리할 수 있도록 API를 추가했습니다.

3. **Service 및 Repository 리팩토링**
   - `WorkbookService`, `SolveLogService` 등에서 기존 문제 조회 및 채점 로직을 `ProblemWorkbookMap` 기반으로 수정했습니다.
   - `ProblemRepository`와 `WorkbookRepository`에 고아 조회용 메서드(`findOrphanProblems`, `findOrphanWorkbooks`)를 추가했습니다.

4. **DTO 및 Converter 리팩토링**
   - `ProblemResponse` DTO를 `ProblemWorkbookMap` 기반으로 생성할 수 있도록 수정했습니다.
   - `WorkbookConverter` 또한 문제 목록을 `ProblemWorkbookMap` 기준으로 변환하도록 변경했습니다.

5. **애플리케이션 설정 변경**
   - `@EnableScheduling` 어노테이션 추가로 스케쥴러 기능을 활성화했습니다.
   - 관련 설정 프로퍼티를 등록할 수 있도록 `@EnableConfigurationProperties` 적용했습니다.

6. **추가 테스트 및 보완**
   - 신규 매핑 구조를 반영하여 테스트 케이스를 추가하거나 수정했습니다.
   - 전체적으로 주석을 보완하여 코드 가독성을 높였습니다.

## 📸스크린샷 (선택)

(변경 사항이 주로 백엔드 로직이라 스크린샷은 생략했습니다.)

## 💬 공유사항 to 리뷰어
오류 있을 수도 있음. 검사 빡세게 필요