### PR TITLE
[Feat #51] 공개 문제집 업로드/다운로드 및 병합 기능 구현

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/repository/FolderRepository.java
@@ -48,4 +48,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     """)
     List<Folder> findAllByUserWithParent(@Param("user") User user); // 폴더 트리 조회
 
+    boolean existsByUserAndFolderWorkbookMaps_Workbook_Id(User user, Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
@@ -92,6 +92,9 @@ public class FolderService {
         if(!folder.getUser().getId().equals(user.getId())) {
             throw new IllegalArgumentException("You do not have permission to move this folder");
         }
+        if(folderId == getRootFolder(user).getId()) {
+            throw new IllegalArgumentException("Cannot move root folder");
+        }
 
 
         Folder targetParent = folderRepository.findById(targetParentId)

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/service/FolderService.java
@@ -83,6 +83,12 @@ public class FolderService {
         return folderRepository.findAllByUserWithParent(user);
     }
 
+    // 유저의 개인 폴더 안에 존재하는 문제집 ID 인지 검사
+    public boolean isWorkbookInUserFolder(User user, Long workbookId) {
+        log.info("isWorkbookInUserFolder request: {}", workbookId);
+        return folderRepository.existsByUserAndFolderWorkbookMaps_Workbook_Id(user, workbookId);
+    }
+
 
     @Transactional
     public Folder moveFolder(User user, Long folderId, Long targetParentId) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/converter/ProblemConverter.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.problem.converter;
 
+import gnu.capstone.G_Learn_E.domain.problem.dto.request.ProblemRequest;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
@@ -125,5 +126,51 @@ public class ProblemConverter {
         }
 
         return result;
+    }
+
+
+    public static Problem convertToProblem(ProblemRequest problemRequest) {
+        switch (problemRequest.type()) {
+            case "MULTIPLE" -> {
+                return Problem.builder()
+                        .title(problemRequest.title())
+                        .options(convertOptions(problemRequest.options()))
+                        .answers(problemRequest.answers())
+                        .explanation(problemRequest.explanation())
+                        .type(ProblemType.MULTIPLE)
+                        .build();
+            }
+            case "OX" -> {
+                return Problem.builder()
+                        .title(problemRequest.title())
+                        .options(null)
+                        .answers(problemRequest.answers())
+                        .explanation(problemRequest.explanation())
+                        .type(ProblemType.OX)
+                        .build();
+            }
+            case "BLANK" -> {
+                return Problem.builder()
+                        .title(problemRequest.title())
+                        .options(null)
+                        .answers(problemRequest.answers())
+                        .explanation(problemRequest.explanation())
+                        .type(ProblemType.BLANK)
+                        .build();
+            }
+            case "DESCRIPTIVE" -> {
+                return Problem.builder()
+                        .title(problemRequest.title())
+                        .options(null)
+                        .answers(problemRequest.answers())
+                        // 서술형 문제는 해설이 없는 경우도 있음
+                        .explanation(null)
+                        .type(ProblemType.DESCRIPTIVE)
+                        .build();
+            }
+            default -> {
+                throw new IllegalArgumentException("Invalid problem type: " + problemRequest.type());
+            }
+        }
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/request/ProblemRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/request/ProblemRequest.java
@@ -1,0 +1,14 @@
+package gnu.capstone.G_Learn_E.domain.problem.dto.request;
+
+import java.util.List;
+
+public record ProblemRequest(
+        Long id,               // 문제 ID
+        String type,           // 문제 유형
+        String title,          // 문제 제목
+        List<String> options,  // 객관식 보기 (Option.content)
+        List<String> answers,  // 정답 리스트
+        String explanation    // 해설
+) {
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/enums/ProblemType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/enums/ProblemType.java
@@ -1,5 +1,15 @@
 package gnu.capstone.G_Learn_E.domain.problem.enums;
 
 public enum ProblemType {
-    MULTIPLE, BLANK, OX, DESCRIPTIVE
+    MULTIPLE, BLANK, OX, DESCRIPTIVE;
+
+    public static ProblemType from(String type) {
+        return switch (type) {
+            case "MULTIPLE" -> MULTIPLE;
+            case "BLANK" -> BLANK;
+            case "OX" -> OX;
+            case "DESCRIPTIVE" -> DESCRIPTIVE;
+            default -> throw new IllegalArgumentException("Invalid problem type: " + type);
+        };
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
@@ -17,4 +17,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
         WHERE p.problemWorkbookMaps IS EMPTY
     """)
     List<Problem> findOrphanProblems();
+
+    // 문제집 ID 리스트에 속하는 문제 조회
+    List<Problem> findAllByProblemWorkbookMaps_Workbook_IdIn(List<Long> workbookIds);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemService.java
@@ -1,9 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.problem.service;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 
 @Slf4j
@@ -14,4 +17,12 @@ public class ProblemService {
     private final ProblemRepository problemRepository;
 
 
+    /**
+     * 문제집 ID 리스트에 속하는 문제 조회
+     * @param workbookIds 문제집 ID 리스트
+     * @return 문제 리스트
+     */
+    public List<Problem> findAllByWorkbookIds(List<Long> workbookIds) {
+        return problemRepository.findAllByProblemWorkbookMaps_Workbook_IdIn(workbookIds);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -55,7 +55,7 @@ public class PublicFolderController {
     @GetMapping("/workbooks/{subject_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooks(@PathVariable("subject_id") Long subjectId) {
 
-        List<Workbook> workbooks = publicFolderService.getWorkbooksBySubjectId(subjectId);
+        List<Workbook> workbooks = publicFolderService.getWorkbooksBySubjectIdWithAuthor(subjectId);
         List<WorkbookResponse> response = workbooks.stream()
                 .map(WorkbookResponse::from)
                 .toList();

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/WorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/WorkbookResponse.java
@@ -25,12 +25,14 @@ public record WorkbookResponse(
 
     public record Author(
             Long userId,
-            String name
+            String name,
+            String nickname
     ) {
         public static Author from(User user) {
             return new Author(
                     user.getId(),
-                    user.getName()
+                    user.getName(),
+                    user.getNickname()
             );
         }
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/WorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/WorkbookResponse.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.public_folder.dto.response;
 
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 
 import java.time.LocalDateTime;
@@ -9,14 +10,28 @@ public record WorkbookResponse(
         Long id,
         String name,
         Integer coverImage,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Author author
 ) {
     public static WorkbookResponse from(Workbook workbook) {
         return new WorkbookResponse(
                 workbook.getId(),
                 workbook.getName(),
                 workbook.getCoverImage(),
-                workbook.getCreatedAt()
+                workbook.getCreatedAt(),
+                Author.from(workbook.getAuthor())
         );
+    }
+
+    public record Author(
+            Long userId,
+            String name
+    ) {
+        public static Author from(User user) {
+            return new Author(
+                    user.getId(),
+                    user.getName()
+            );
+        }
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/SubjectWorkbookId.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/SubjectWorkbookId.java
@@ -1,14 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.public_folder.entity;
 
 import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 
 @Getter
+@Setter
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/SubjectWorkbookMap.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/SubjectWorkbookMap.java
@@ -2,12 +2,16 @@ package gnu.capstone.G_Learn_E.domain.public_folder.entity;
 
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class SubjectWorkbookMap {
 
     @EmbeddedId

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/DepartmentRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/DepartmentRepository.java
@@ -11,5 +11,7 @@ import java.util.Optional;
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
     Optional<Department> findByNameAndCollegeId(String name, Long collegeId);
     List<Department> findByCollegeId(Long collegeId);
+
+    Optional<Department> findByIdAndCollegeId(Long id, Long collegeId);
 }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
     boolean existsByNameAndDepartmentId(String name, Long departmentId);
     boolean existsByNameAndGradeAndDepartmentId(String name, SubjectGrade grade, Long departmentId);
     List<Subject> findByDepartmentId(Long departmentId);
+
+    Optional<Subject> findByIdAndDepartmentId(Long id, Long departmentId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectWorkbookMapRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface SubjectWorkbookMapRepository extends JpaRepository<SubjectWorkbookMap, SubjectWorkbookId> {
     List<SubjectWorkbookMap> findAllBySubject_Id(Long subjectId);
+
+    boolean existsByWorkbook_Id(Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -50,4 +50,14 @@ public class PublicFolderService {
         return workbookRepository.findAllBySubjectId(subjectId);
     }
 
+    public Subject findSubjectInTree(Long collegeId, Long departmentId, Long subjectId) {
+        // collegeId, departmentId, subjectId로 Subject 조회
+        College college = collegeRepository.findById(collegeId)
+                .orElseThrow(() -> new RuntimeException("College not found"));
+        Department department = departmentRepository.findByIdAndCollegeId(departmentId, collegeId)
+                .orElseThrow(() -> new RuntimeException("Department not found"));
+        return subjectRepository.findByIdAndDepartmentId(subjectId, departmentId)
+                .orElseThrow(() -> new RuntimeException("Subject not found"));
+    }
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -46,8 +46,8 @@ public class PublicFolderService {
         return subjects;
     }
 
-    public List<Workbook> getWorkbooksBySubjectId(Long subjectId) {
-        return workbookRepository.findAllBySubjectId(subjectId);
+    public List<Workbook> getWorkbooksBySubjectIdWithAuthor(Long subjectId) {
+        return workbookRepository.findAllWithAuthorBySubjectId(subjectId);
     }
 
     public Subject findSubjectInTree(Long collegeId, Long departmentId, Long subjectId) {
@@ -58,6 +58,10 @@ public class PublicFolderService {
                 .orElseThrow(() -> new RuntimeException("Department not found"));
         return subjectRepository.findByIdAndDepartmentId(subjectId, departmentId)
                 .orElseThrow(() -> new RuntimeException("Subject not found"));
+    }
+
+    public boolean isPublicWorkbook(Long workbookId) {
+        return subjectWorkbookMapRepository.existsByWorkbook_Id(workbookId);
     }
 
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
@@ -1,5 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.controller;
 
+import gnu.capstone.G_Learn_E.domain.folder.service.FolderService;
+import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
@@ -22,6 +24,8 @@ public class SolveLogController {
 
     private final WorkbookService workbookService;
     private final SolveLogService solveLogService;
+    private final FolderService folderService;
+    private final PublicFolderService publicFolderService;
 
 
     @PatchMapping("/workbook/{workbookId}")
@@ -30,6 +34,11 @@ public class SolveLogController {
             @PathVariable("workbookId") Long workbookId,
             @RequestBody SaveSolveLogRequest request
     ){
+        if(!folderService.isWorkbookInUserFolder(user, workbookId) &&
+                !publicFolderService.isPublicWorkbook(workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
+
         Workbook workbook = workbookService.findWorkbookById(workbookId);
         SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
 
@@ -43,6 +52,11 @@ public class SolveLogController {
             @AuthenticationPrincipal User user,
             @PathVariable("workbookId") Long workbookId
     ){
+        if(!folderService.isWorkbookInUserFolder(user, workbookId) &&
+                !publicFolderService.isPublicWorkbook(workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
+
         Workbook workbook = workbookService.findWorkbookById(workbookId);
         SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -1,9 +1,13 @@
 package gnu.capstone.G_Learn_E.domain.workbook.controller;
 
+import gnu.capstone.G_Learn_E.domain.folder.service.FolderService;
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.WorkbookMergeRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.WorkbookUpload;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.WorkbookUploadList;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.*;
@@ -23,6 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -31,7 +36,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WorkbookController {
 
+    private final ProblemService problemService;
     private final WorkbookService workbookService;
+    private final FolderService folderService;
     private final PublicFolderService publicFolderService;
     private final SolveLogService solveLogService;
     private final FastApiService fastApiService;
@@ -55,43 +62,19 @@ public class WorkbookController {
     }
 
     /**
-     * 문제 풀이 페이지 로드
+     * 개인 폴더 문제 풀이 페이지 로드
      */
     @GetMapping("/{workbookId}/solve")
     public ApiResponse<WorkbookSolveResponse> problemSolvePageLoad(
             @AuthenticationPrincipal User user,
             @PathVariable("workbookId") Long workbookId
     ){
-        Workbook workbook = workbookService.findUsersWorkbookByIdWithProblems(workbookId, user);
-        log.info("문제집 조회 성공 : {}", workbook);
-
-        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
-        log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
-
-        Map<Long, SolveLog> solveLogToMap = solveLogService.findAllSolveLogToMap(solvedWorkbook);
-        log.info("문제 풀이 기록 조회 성공 : {}", solveLogToMap);
-
-        WorkbookSolveResponse response = WorkbookConverter.convertToWorkbookSolveResponse(
-                workbook,
-                solvedWorkbook,
-                workbook.getProblemWorkbookMaps(),
-                solveLogToMap
-        );
-        log.info("문제 풀이 페이지 로드 성공 : {}", response);
-        return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
-    }
-
-
-    @GetMapping("/{workbookId}/solve/uploaded")
-    public ApiResponse<WorkbookSolveResponse> problemSolvePageLoadUploaded(
-            @AuthenticationPrincipal User user,
-            @PathVariable("workbookId") Long workbookId
-    ){
         Workbook workbook = workbookService.findWorkbookByIdWithProblems(workbookId);
-        if(!workbook.isUploaded() || !publicFolderService.isPublicWorkbook(workbookId)) {
-            throw new RuntimeException("업로드 된 문제집이 아닙니다.");
-        }
         log.info("문제집 조회 성공 : {}", workbook);
+        if(!folderService.isWorkbookInUserFolder(user, workbookId) &&
+                !publicFolderService.isPublicWorkbook(workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
 
         SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
         log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
@@ -108,8 +91,6 @@ public class WorkbookController {
         log.info("문제 풀이 페이지 로드 성공 : {}", response);
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
     }
-
-
 
     @PostMapping("/{workbookId}/grade")
     public ApiResponse<?> gradeWorkbook(
@@ -117,7 +98,11 @@ public class WorkbookController {
             @PathVariable("workbookId") Long workbookId,
             @RequestBody SaveSolveLogRequest request
     ){
-        Workbook workbook = workbookService.findUsersWorkbookByIdWithProblems(workbookId, user);
+        if(!folderService.isWorkbookInUserFolder(user, workbookId) &&
+                !publicFolderService.isPublicWorkbook(workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
+        Workbook workbook = workbookService.findWorkbookByIdWithProblems(workbookId);
         GradeWorkbookResponse response = solveLogService.gradeWorkbook(user, workbook, request);
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 채점 성공", response);
     }
@@ -158,4 +143,29 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제집 다운로드 성공", response);
     }
 
+    @GetMapping("/merge")
+    public ApiResponse<?> mergeWorkbookPageLoad(
+            @AuthenticationPrincipal User user,
+            @RequestParam("ids") List<Long> workbookIds
+    ){
+        boolean isvalid = workbookIds.stream()
+                // 하나라도 isInUserFolders == false가 있으면 allMatch 전체가 false
+                .allMatch(id -> folderService.isWorkbookInUserFolder(user, id));
+        if(!isvalid) {
+            throw new RuntimeException("문제집이 유저의 폴더에 존재하지 않습니다.");
+        }
+        List<Problem> problems = problemService.findAllByWorkbookIds(workbookIds);
+        WorkbookMergePageResponse response = WorkbookMergePageResponse.from(problems);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 병합 페이지 로드 성공", response);
+    }
+
+    @PostMapping("/merge")
+    public ApiResponse<?> mergeWorkbook(
+            @AuthenticationPrincipal User user,
+            @RequestBody WorkbookMergeRequest request
+    ){
+        Workbook workbook = workbookService.createWorkbookFromProblems(request.problems(), user);
+        WorkbookResponse response = WorkbookResponse.of(workbook);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 병합 성공", response);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -147,4 +147,15 @@ public class WorkbookController {
 
         return new ApiResponse<>(HttpStatus.OK, "문제집 리스트 업로드 성공", null);
     }
+
+    @PostMapping("/{workbookId}/download")
+    public ApiResponse<?> downloadWorkbook(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId
+    ){
+        Workbook workbook = workbookService.downloadWorkbook(workbookId, user);
+        WorkbookDownloadResponse response = WorkbookDownloadResponse.of(workbook.getId());
+        return new ApiResponse<>(HttpStatus.OK, "문제집 다운로드 성공", response);
+    }
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -2,6 +2,7 @@ package gnu.capstone.G_Learn_E.domain.workbook.controller;
 
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.WorkbookUpload;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.GradeWorkbookResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.WorkbookSolveResponse;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
@@ -114,5 +115,14 @@ public class WorkbookController {
 
         GradeWorkbookResponse response = solveLogService.gradeAllSolveLog(user, workbook, problemMap);
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 채점 성공", response);
+    }
+
+    @PostMapping("/upload")
+    public ApiResponse<?> uploadWorkbook(
+            @AuthenticationPrincipal User user,
+            @RequestBody List<WorkbookUpload> request
+    ){
+
+        return new ApiResponse<>(HttpStatus.OK, "문제집 업로드 성공", null);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -81,6 +81,36 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
     }
 
+
+    @GetMapping("/{workbookId}/solve/uploaded")
+    public ApiResponse<WorkbookSolveResponse> problemSolvePageLoadUploaded(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId
+    ){
+        Workbook workbook = workbookService.findWorkbookByIdWithProblems(workbookId);
+        if(!workbook.isUploaded() || !publicFolderService.isPublicWorkbook(workbookId)) {
+            throw new RuntimeException("업로드 된 문제집이 아닙니다.");
+        }
+        log.info("문제집 조회 성공 : {}", workbook);
+
+        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+        log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
+
+        Map<Long, SolveLog> solveLogToMap = solveLogService.findAllSolveLogToMap(solvedWorkbook);
+        log.info("문제 풀이 기록 조회 성공 : {}", solveLogToMap);
+
+        WorkbookSolveResponse response = WorkbookConverter.convertToWorkbookSolveResponse(
+                workbook,
+                solvedWorkbook,
+                workbook.getProblemWorkbookMaps(),
+                solveLogToMap
+        );
+        log.info("문제 풀이 페이지 로드 성공 : {}", response);
+        return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
+    }
+
+
+
     @PostMapping("/{workbookId}/grade")
     public ApiResponse<?> gradeWorkbook(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookMergeRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookMergeRequest.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+import gnu.capstone.G_Learn_E.domain.problem.dto.request.ProblemRequest;
+
+import java.util.List;
+
+public record WorkbookMergeRequest(
+        List<ProblemRequest> problems // 문제 리스트
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpload.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpload.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+public record WorkbookUpload(
+        Long id,
+        Long collegeId,
+        Long departmentId,
+        Long subjectId
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpload.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpload.java
@@ -1,9 +1,8 @@
 package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
 
 public record WorkbookUpload(
-        Long id,
         Long collegeId,
         Long departmentId,
         Long subjectId
-) {
+){
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUploadList.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUploadList.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+import java.util.List;
+
+public record WorkbookUploadList(
+        List<WorkbookUpload> uploadList
+) {
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookDownloadResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookDownloadResponse.java
@@ -1,0 +1,11 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
+
+public record WorkbookDownloadResponse(
+        Long id
+) {
+    public static WorkbookDownloadResponse of(
+            Long id
+    ) {
+        return new WorkbookDownloadResponse(id);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookMergePageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookMergePageResponse.java
@@ -1,0 +1,35 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.ProblemResponse;
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.global.common.serialization.Option;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public record WorkbookMergePageResponse(
+        List<ProblemResponse> problems // 문제 리스트
+) {
+    public static WorkbookMergePageResponse from(List<Problem> problems) {
+        AtomicInteger problemNumber = new AtomicInteger(1);
+        List<ProblemResponse> list = problems.stream()
+                .map(p -> {
+                    // 반드시 new 키워드로 생성자 호출
+                    return new ProblemResponse(
+                            p.getId(),
+                            problemNumber.getAndIncrement(),
+                            p.getType().name(),
+                            p.getTitle(),
+                            p.getOptions() == null
+                                    ? List.of()
+                                    : p.getOptions().stream()
+                                    .map(Option::getContent)
+                                    .toList(),
+                            p.getAnswers(),
+                            p.getExplanation()
+                    );
+                })
+                .toList();
+        return new WorkbookMergePageResponse(list);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookUploadResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookUploadResponse.java
@@ -1,0 +1,25 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
+
+public record WorkbookUploadResponse(
+        Long id,
+        Subject subject
+) {
+    public static WorkbookUploadResponse of(
+            Long id,
+            Long subjectId,
+            String subjectName
+    ) {
+        return new WorkbookUploadResponse(
+                id,
+                Subject.of(subjectId, subjectName)
+                );
+    }
+    record Subject(
+            Long id,
+            String name
+    ) {
+        public static Subject of(Long id, String name) {
+            return new Subject(id, name);
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -5,12 +5,14 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.Semester;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -25,6 +27,10 @@ public class Workbook {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private User author;
+
     private String name;
     private String professor;
 
@@ -38,6 +44,8 @@ public class Workbook {
     private Semester semester;
 
     private LocalDateTime createdAt;
+
+    @Setter
     private boolean isUploaded;
 
     @OneToMany(mappedBy = "workbook", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
@@ -64,7 +72,9 @@ public class Workbook {
                     ExamType examType,
                     Integer coverImage,
                     Integer courseYear,
-                    Semester semester) {
+                    Semester semester,
+                    User author
+    ) {
         this.name = name;
         this.professor = professor;
         this.examType = examType;
@@ -72,6 +82,7 @@ public class Workbook {
         this.courseYear = courseYear;
         this.semester = semester;
         this.isUploaded = false;
+        this.author = author;
     }
 
     /**

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.workbook.repository;
 
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -1,6 +1,5 @@
 package gnu.capstone.G_Learn_E.domain.workbook.repository;
 
-import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,8 +12,14 @@ import java.util.Optional;
 
 @Repository
 public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
-    @Query("SELECT swm.workbook FROM SubjectWorkbookMap swm WHERE swm.subject.id = :subjectId")
-    List<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId);
+    @Query("""
+        select distinct w
+        from SubjectWorkbookMap swm
+        join swm.workbook w
+        join fetch w.author
+        where swm.subject.id = :subjectId
+    """)
+    List<Workbook> findAllWithAuthorBySubjectId(@Param("subjectId") Long subjectId);
 
     @EntityGraph(attributePaths = {
             "problemWorkbookMaps",


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#51

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->
- 공개 문제집 업로드/다운로드 기능 추가
- 문제집 병합 기능 및 페이지 API 추가
- SolveLog 접근 권한 검증 로직 추가
- ProblemRequest 및 Converter 로직 구현
- Workbook 도메인에 author 필드 추가 및 관련 로직 보완
- PublicFolderService 기능 강화 (권한 검증, 상세 조회 등)
- 불필요한 로그 제거 및 코드 리팩토링

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->
1. **공개 문제집 업로드/다운로드 기능 추가**
   - 개인 문제집을 공개폴더(Subject)에 업로드하는 API(`POST /workbooks/{id}/upload`) 구현.
   - 공개 문제집을 개인 폴더로 다운로드하는 기능(`POST /workbooks/{id}/download`) 구현.
   - Workbook 엔티티에 `author` 및 `isUploaded` 필드 추가, 관련 로직 반영.

2. **문제집 병합 기능 추가**
   - 여러 문제집을 하나로 병합할 수 있는 병합 페이지 로딩 API(`GET /workbooks/merge`) 및 병합 수행 API(`POST /workbooks/merge`) 구현.
   - 병합시 기존 문제를 재사용하거나 새로 생성해 저장하도록 처리.

3. **SolveLog 접근 권한 강화**
   - SolveLog 관련 API 접근 시 `개인폴더 또는 공개폴더에 속한 문제집`에 대해서만 접근 가능하도록 검증 추가.

4. **ProblemRequest 및 Converter 로직 구현**
   - 문제 유형(MULTIPLE, OX, BLANK, DESCRIPTIVE)에 따라 문제 생성이 가능하도록 `ProblemRequest` DTO 및 변환 메서드 구현.

5. **Workbook 도메인 필드 확장**
   - 문제집에 `작성자(author)` 정보와 업로드 여부 플래그(`isUploaded`) 필드를 추가하고, 관련 DTO 및 엔티티 변경 사항 반영.

6. **PublicFolderService 기능 보완**
   - `isPublicWorkbook`, `findSubjectInTree` 등의 메서드 추가로 공개 문제집 확인과 Subject 접근 경로 검증을 강화.

7. **기타 리팩토링**
   - SolveLogService에서 중복 로그 제거, 가독성 향상 위한 주석 정리 및 메서드 간소화.
   - 컨트롤러/서비스 레벨에서의 예외 메시지 구체화.

## 📸스크린샷 (선택)


## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
