### PR TITLE
[Feat #55] Swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/folder/controller/FolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/folder/controller/FolderController.java
@@ -13,6 +13,8 @@ import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -28,6 +30,7 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/api/folder/private")
+@Tag(name = "개인 폴더 API")
 @RequiredArgsConstructor
 public class FolderController {
 
@@ -35,6 +38,7 @@ public class FolderController {
     private final WorkbookService workbookService;
 
 
+    @Operation(summary = "폴더 조회", description = "폴더 + 하위폴더 + 문제집을 조회합니다.")
     @GetMapping("/{folderId}")
     public ApiResponse<FolderResponse> getFolder(
             @AuthenticationPrincipal User user,
@@ -51,6 +55,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 조회에 성공하였습니다.", response);
     }
 
+    @Operation(summary = "루트 폴더 조회", description = "루트 폴더 + 하위폴더 + 문제집을 조회합니다.")
     @GetMapping
     public ApiResponse<FolderResponse> getFolder(
             @AuthenticationPrincipal User user
@@ -62,6 +67,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 조회에 성공하였습니다.", response);
     }
 
+    @Operation(summary = "폴더 트리 조회", description = "폴더 트리를 조회합니다.")
     @GetMapping("/folder-tree")
     public ApiResponse<FolderTreeResponse> getFolderTree(
             @AuthenticationPrincipal User user
@@ -95,6 +101,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 트리 조회에 성공하였습니다.", response);
     }
 
+    @Operation(summary = "폴더 생성", description = "폴더를 생성합니다.")
     @PostMapping
     public ApiResponse<FolderResponse> createFolder(
             @AuthenticationPrincipal User user,
@@ -109,6 +116,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 생성에 성공하였습니다.", response);
     }
 
+    @Operation(summary = "폴더 이동", description = "폴더를 이동합니다.")
     @PatchMapping("/{folderId}/move")
     public ApiResponse<?> moveFolder(
             @AuthenticationPrincipal User user,
@@ -124,6 +132,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 이동에 성공하였습니다.", response);
     }
 
+    @Operation(summary = "폴더 이름 변경", description = "폴더 이름을 변경합니다.")
     @PatchMapping("/{folderId}/rename")
     public ApiResponse<?> renameFolder(
             @AuthenticationPrincipal User user,
@@ -137,6 +146,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 이름 변경에 성공하였습니다.", response);
     }
 
+    @Operation(summary = "폴더 삭제", description = "폴더를 삭제합니다.")
     @DeleteMapping("/{folderId}")
     public ApiResponse<?> deleteFolder(
             @AuthenticationPrincipal User user,
@@ -149,6 +159,7 @@ public class FolderController {
         return new ApiResponse<>(HttpStatus.OK, "폴더 삭제에 성공하였습니다.", null);
     }
 
+    @Operation(summary = "문제집 삭제", description = "폴더에서 문제집을 삭제합니다.")
     @DeleteMapping("/{folderId}/workbook/{workbookId}")
     public ApiResponse<?> deleteWorkbookFromFolder(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/notification/controller/NotificationController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/notification/controller/NotificationController.java
@@ -4,6 +4,8 @@ import gnu.capstone.G_Learn_E.domain.notification.dto.response.NotificationRespo
 import gnu.capstone.G_Learn_E.domain.notification.service.NotificationService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,11 +17,13 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequestMapping("/api/notification")
+@Tag(name = "알림 API")
 @RequiredArgsConstructor
 public class NotificationController {
 
     private final NotificationService notificationService;
 
+    @Operation(summary = "알림 조회", description = "사용자의 알림을 조회합니다.")
     @GetMapping
     public ApiResponse<List<NotificationResponse>> getNotificationsByUserId(
             @AuthenticationPrincipal User user,
@@ -30,7 +34,7 @@ public class NotificationController {
         return new ApiResponse<>(HttpStatus.OK, "알림 조회에 성공했습니다.", notifications);
     }
 
-
+    @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
     @DeleteMapping("/{notificationId}")
     public ApiResponse<?> deleteNotification(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -8,6 +8,8 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,12 +23,14 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequestMapping("/api/folder/public")
+@Tag(name = "Public 폴더 API")
 @RequiredArgsConstructor
 public class PublicFolderController {
 
     private final PublicFolderService publicFolderService;
 
-    // TODO : 공용 폴더 컨트롤러 구현
+
+    @Operation(summary = "단과대 목록 조회", description = "단과대 목록을 조회합니다.")
     @GetMapping("/colleges")
     public ApiResponse<List<CollegeResponse>> getColleges() {
         List<College> colleges = publicFolderService.getColleges();
@@ -35,6 +39,8 @@ public class PublicFolderController {
         ).toList();
         return new ApiResponse<>(HttpStatus.OK, "단과대 목록 조회 성공", response);
     }
+
+    @Operation(summary = "학과 목록 조회", description = "학과 목록을 조회합니다.")
     @GetMapping("/departments/{college_id}")
     public ApiResponse<List<DepartmentResponse>> getDepartments(@PathVariable("college_id") Long collegeId) {
         List<Department> departments = publicFolderService.getDepartmentsByCollegeId(collegeId);
@@ -43,6 +49,8 @@ public class PublicFolderController {
                 .toList();
         return new ApiResponse<>(HttpStatus.OK, "학과 목록 조회 성공", response);
     }
+
+    @Operation(summary = "과목 목록 조회", description = "과목 목록을 조회합니다.")
     @GetMapping("/subjects/{department_id}")
     public ApiResponse<List<SubjectResponse>> getSubjects(@PathVariable("department_id") Long departmentId) {
         List<Subject> subjects = publicFolderService.getSubjectsByDepartmentId(departmentId);
@@ -52,6 +60,8 @@ public class PublicFolderController {
 
         return new ApiResponse<>(HttpStatus.OK, "과목 목록 조회 성공", response);
     }
+
+    @Operation(summary = "문제집 목록 조회", description = "과목 폴더에서 문제집 목록을 조회합니다.")
     @GetMapping("/workbooks/{subject_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooks(@PathVariable("subject_id") Long subjectId) {
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
@@ -9,16 +9,18 @@ import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-
 @Slf4j
 @RestController
 @RequestMapping("/api/solve-log")
+@Tag(name = "풀이 로그 API")
 @RequiredArgsConstructor
 public class SolveLogController {
 
@@ -28,6 +30,7 @@ public class SolveLogController {
     private final PublicFolderService publicFolderService;
 
 
+    @Operation(summary = "풀이 로그 업데이트", description = "풀이 로그를 업데이트합니다.")
     @PatchMapping("/workbook/{workbookId}")
     public ApiResponse<?> saveUserAnswer(
             @AuthenticationPrincipal User user,
@@ -47,6 +50,7 @@ public class SolveLogController {
         return new ApiResponse<>(HttpStatus.OK, "풀이 로그 저장 성공", null);
     }
 
+    @Operation(summary = "풀이 로그 삭제", description = "풀이 로그를 삭제합니다.")
     @DeleteMapping("/workbook/{workbookId}")
     public ApiResponse<?> deleteUsersSolveLog(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -6,6 +6,8 @@ import gnu.capstone.G_Learn_E.domain.user.dto.response.UserInfoResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,16 +17,20 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequestMapping("/api/user")
+@Tag(name = "유저 API")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+
+    @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다.")
     @GetMapping
     public ApiResponse<UserInfoResponse> getInfo(@AuthenticationPrincipal User user) {
         UserInfoResponse response = UserInfoResponse.from(user);
         return new ApiResponse<>(HttpStatus.OK, "유저 정보 조회 성공", response);
     }
 
+    @Operation(summary = "유저 경험치 증가", description = "유저의 경험치를 증가시킵니다.")
     @PostMapping("/exp/gain")
     public ApiResponse<UserInfoResponse> gainExp(
             @AuthenticationPrincipal User user,
@@ -35,6 +41,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "경험치가 증가했습니다.", response);
     }
 
+    @Operation(summary = "유저 닉네임 변경", description = "유저의 닉네임을 변경합니다.")
     @PatchMapping("/nickname")
     public ApiResponse<UserInfoResponse> updateNickname(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -20,6 +20,8 @@ import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.service.WorkbookService;
 import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -33,6 +35,7 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/api/workbook")
+@Tag(name = "문제집 API")
 @RequiredArgsConstructor
 public class WorkbookController {
 
@@ -44,6 +47,7 @@ public class WorkbookController {
     private final FastApiService fastApiService;
 
 
+    @Operation(summary = "문제집 생성", description = "문제집을 생성합니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, path = "/generate")
     public ApiResponse<WorkbookResponse> createWorkbook(
             @AuthenticationPrincipal User user,
@@ -64,6 +68,7 @@ public class WorkbookController {
     /**
      * 개인 폴더 문제 풀이 페이지 로드
      */
+    @Operation(summary = "문제 풀이 페이지 로드", description = "문제 풀이 페이지를 로드합니다.")
     @GetMapping("/{workbookId}/solve")
     public ApiResponse<WorkbookSolveResponse> problemSolvePageLoad(
             @AuthenticationPrincipal User user,
@@ -92,6 +97,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 페이지 로드 성공", response);
     }
 
+    @Operation(summary = "문제 풀이 채점", description = "문제 풀이를 채점합니다.")
     @PostMapping("/{workbookId}/grade")
     public ApiResponse<?> gradeWorkbook(
             @AuthenticationPrincipal User user,
@@ -107,6 +113,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 채점 성공", response);
     }
 
+    @Operation(summary = "문제집 업로드", description = "문제집을 public 폴더에 업로드합니다.")
     @PostMapping("/{workbookId}/upload")
     public ApiResponse<?> uploadWorkbook(
             @AuthenticationPrincipal User user,
@@ -124,6 +131,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제집 업로드 성공", response);
     }
 
+    @Operation(summary = "문제집 리스트 업로드", description = "문제집 리스트를 public 폴더에 업로드합니다. (TODO)")
     @PostMapping("/upload/list")
     public ApiResponse<?> uploadWorkbookList(
             @AuthenticationPrincipal User user,
@@ -133,6 +141,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제집 리스트 업로드 성공", null);
     }
 
+    @Operation(summary = "문제집 다운로드", description = "문제집을 다운로드합니다.")
     @PostMapping("/{workbookId}/download")
     public ApiResponse<?> downloadWorkbook(
             @AuthenticationPrincipal User user,
@@ -143,6 +152,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제집 다운로드 성공", response);
     }
 
+    @Operation(summary = "문제집 병합 페이지 로드", description = "문제집 병합 페이지를 로드합니다.")
     @GetMapping("/merge")
     public ApiResponse<?> mergeWorkbookPageLoad(
             @AuthenticationPrincipal User user,
@@ -159,6 +169,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제집 병합 페이지 로드 성공", response);
     }
 
+    @Operation(summary = "문제집 병합", description = "여러 문제집을 병합합니다.")
     @PostMapping("/merge")
     public ApiResponse<?> mergeWorkbook(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/global/admin/AdminController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/admin/AdminController.java
@@ -4,6 +4,8 @@ package gnu.capstone.G_Learn_E.global.admin;
 import gnu.capstone.G_Learn_E.global.admin.dto.CleanupResult;
 import gnu.capstone.G_Learn_E.global.scheduler.OrphanCleanupScheduler;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,12 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/admin")
+@Tag(name = "관리자 API")
 @RequiredArgsConstructor
 public class AdminController {
 
     private final OrphanCleanupScheduler cleanupScheduler;
 
     /** 관리자 전용 즉시 정리 엔드포인트 */
+    @Operation(summary = "고아 엔티티 정리", description = "고아 엔티티를 즉시 정리합니다. (문제집, 문제 엔티티)")
     @DeleteMapping("/orphans")
     public ApiResponse<CleanupResult> triggerCleanup() {
         CleanupResult result = cleanupScheduler.cleanUpNow();

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -14,6 +14,8 @@ import gnu.capstone.G_Learn_E.global.auth.util.EmailValidator;
 import gnu.capstone.G_Learn_E.global.jwt.service.JwtService;
 import gnu.capstone.G_Learn_E.global.mail.EmailSender;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
+@Tag(name = "인증 API")
 @RequiredArgsConstructor
 public class AuthController {
 
@@ -35,6 +38,7 @@ public class AuthController {
     private final JwtService jwtService;
 
 
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
     public ApiResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
         String email = request.email();
@@ -49,6 +53,7 @@ public class AuthController {
         return new ApiResponse<>(HttpStatus.OK, "로그인 성공", tokenResponse);
     }
 
+    @Operation(summary = "회원가입", description = "이메일 인증 후 회원가입합니다.")
     @PostMapping("/signup")
     public ApiResponse<TokenResponse> signUp(HttpServletRequest request, @Valid @RequestBody SignupRequest dto) {
         // 회원가입
@@ -76,6 +81,7 @@ public class AuthController {
         return new ApiResponse<>(HttpStatus.CREATED, "회원가입 성공", tokenResponse);
     }
 
+    @Operation(summary = "이메일 인증 코드 발급", description = "이메일 인증 코드를 발급합니다.")
     @GetMapping("/email-code")
     public ApiResponse<?> getEmailAuthCode(@RequestParam("email") String email) {
         // TODO : 이메일 검증
@@ -87,6 +93,7 @@ public class AuthController {
         return new ApiResponse<>(HttpStatus.NO_CONTENT, "이메일 인증 코드 발급 성공", null);
     }
 
+    @Operation(summary = "이메일 인증 코드 검증", description = "이메일 인증 코드를 검증합니다.")
     @PostMapping("/email-code/verify")
     public ApiResponse<EmailAuthToken> verifyEmailAuthCode(@RequestBody EmailAuthCodeVerify request) {
         // TODO : 이메일 인증 코드 검증
@@ -100,6 +107,7 @@ public class AuthController {
         return new ApiResponse<>(HttpStatus.OK, responseMsg, new EmailAuthToken(emailAuthToken));
     }
 
+    @Operation(summary = "엑세스 토큰 재발급", description = "엑세스 토큰을 재발급합니다.")
     @PatchMapping("/reissue")
     public ApiResponse<AccessTokenResponse> reissue(@AuthenticationPrincipal User user, HttpServletRequest request) {
         String refreshToken = jwtService.extractToken(request);
@@ -109,6 +117,7 @@ public class AuthController {
         return new ApiResponse<>(HttpStatus.OK, "엑세스 토큰 재발급 성공", response);
     }
 
+    @Operation(summary = "로그아웃", description = "로그아웃합니다. 엑세스 토큰과 리프레시 토큰을 블랙리스트에 추가합니다.")
     @DeleteMapping("/logout")
     public ApiResponse<?> logout(@AuthenticationPrincipal User user, HttpServletRequest request) {
         String accessToken = jwtService.extractToken(request);

--- a/src/main/java/gnu/capstone/G_Learn_E/global/config/SwaggerConfig.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package gnu.capstone.G_Learn_E.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI swaggerDocs() {
+        return new OpenAPI()
+                // 전역으로 “bearerAuth” 스킴을 요구하도록 설정
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/file_upload/controller/FileUploadController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/file_upload/controller/FileUploadController.java
@@ -1,6 +1,8 @@
 package gnu.capstone.G_Learn_E.global.file_upload.controller;
 
 import gnu.capstone.G_Learn_E.global.file_upload.service.FileUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,12 +20,14 @@ import java.nio.file.Path;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "파일 업로드 API, 향후 admin API로 이동 예정")
 @RequestMapping("/dev/api/fileupload")
 public class FileUploadController {
 
     private final FileUploadService fileUploadService;
 
 
+    @Operation(summary = "파일 업로드", description = "경상대 개설과목 json 파일을 업로드합니다.")
     @PostMapping("/upload/public_folder_metadata")
     public ResponseEntity<String> handleFileUpload(@RequestParam("file") MultipartFile file) {
         try {


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #55 -->

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->
- Swagger(OpenAPI) 라이브러리 의존성 추가 (`build.gradle`)
- 전 API 컨트롤러에 Swagger 어노테이션 추가 (`@Tag`, `@Operation`)
- API 문서화를 위한 준비 작업 완료

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->
1. `build.gradle` 파일에 Swagger(OpenAPI)를 사용하기 위한 라이브러리 `springdoc-openapi-starter-webmvc-ui:2.1.0`을 추가하였습니다. 이를 통해 자동 API 문서화가 가능합니다.

2. `FolderController`, `NotificationController`, `PublicFolderController`, `SolveLogController`, `UserController`, `WorkbookController`, `AdminController` 등 주요 API 컨트롤러에 Swagger 문서화를 위한 어노테이션을 추가하였습니다.
   - 각 클래스 상단에 `@Tag(name = "...")` 어노테이션을 추가하여 해당 컨트롤러의 기능을 명시하였습니다.
   - 각 API 메서드에 `@Operation(summary = "...", description = "...")`을 추가하여 Swagger UI에서 API 설명이 명확히 보이도록 했습니다.

3. 해당 작업을 통해 Swagger UI 접속 시 모든 API에 대한 명확한 분류 및 설명을 확인할 수 있으며, 프론트엔드 개발자 및 외부 협업자들이 API를 쉽게 테스트하고 이해할 수 있도록 하였습니다.

## 📸스크린샷 (선택)


## 💬 공유사항 to 리뷰어
플젝 실행하고 http://localhost:8080/swagger-ui/index.html#/ 으로 접속하세요
