### PR TITLE
[Feat #58] 회원가입 시 소속 정보 기입 및 단과대 관련 API 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/DevPublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/DevPublicFolderController.java
@@ -21,8 +21,11 @@ public class DevPublicFolderController {
 
 
     @Operation(summary = "단과대 isCollege 업데이트", description = "단과대 isCollege를 업데이트합니다.")
-    @PatchMapping("/college/{collegeId}/isCollege")
-    public ApiResponse<?> updateIsCollege(@PathVariable String collegeId, @RequestBody UpdateCollege request) {
+    @PatchMapping("/college/{college_id}/isCollege")
+    public ApiResponse<?> updateIsCollege(
+            @PathVariable(name = "college_id") String collegeId,
+            @RequestBody UpdateCollege request
+    ) {
         devPublicFolderService.updateIsCollege(Long.parseLong(collegeId), request.isCollege());
         return new ApiResponse<>(HttpStatus.OK, "단과대 isCollege 업데이트 성공", null);
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/DevPublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/DevPublicFolderController.java
@@ -1,0 +1,29 @@
+package gnu.capstone.G_Learn_E.domain.public_folder.controller;
+
+import gnu.capstone.G_Learn_E.domain.public_folder.dto.request.UpdateCollege;
+import gnu.capstone.G_Learn_E.domain.public_folder.service.DevPublicFolderService;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/dev/api/folder/public")
+@Tag(name = "개발자용 Public 폴더 API")
+@RequiredArgsConstructor
+public class DevPublicFolderController {
+
+    private final DevPublicFolderService devPublicFolderService;
+
+
+    @Operation(summary = "단과대 isCollege 업데이트", description = "단과대 isCollege를 업데이트합니다.")
+    @PatchMapping("/college/{collegeId}/isCollege")
+    public ApiResponse<?> updateIsCollege(@PathVariable String collegeId, @RequestBody UpdateCollege request) {
+        devPublicFolderService.updateIsCollege(Long.parseLong(collegeId), request.isCollege());
+        return new ApiResponse<>(HttpStatus.OK, "단과대 isCollege 업데이트 성공", null);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -13,10 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -32,8 +29,10 @@ public class PublicFolderController {
 
     @Operation(summary = "단과대 목록 조회", description = "단과대 목록을 조회합니다.")
     @GetMapping("/colleges")
-    public ApiResponse<List<CollegeResponse>> getColleges() {
-        List<College> colleges = publicFolderService.getColleges();
+    public ApiResponse<List<CollegeResponse>> getColleges(
+            @RequestParam(value = "isCollege", defaultValue = "true") boolean isCollege
+    ) {
+        List<College> colleges = publicFolderService.getColleges(isCollege);
         List<CollegeResponse> response = colleges.stream().map(
                 CollegeResponse::from
         ).toList();
@@ -64,7 +63,6 @@ public class PublicFolderController {
     @Operation(summary = "문제집 목록 조회", description = "과목 폴더에서 문제집 목록을 조회합니다.")
     @GetMapping("/workbooks/{subject_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooks(@PathVariable("subject_id") Long subjectId) {
-
         List<Workbook> workbooks = publicFolderService.getWorkbooksBySubjectIdWithAuthor(subjectId);
         List<WorkbookResponse> response = workbooks.stream()
                 .map(WorkbookResponse::from)

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/request/UpdateCollege.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/request/UpdateCollege.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.domain.public_folder.dto.request;
+
+public record UpdateCollege(
+        boolean isCollege
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/College.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/College.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +21,10 @@ public class College {
 
     @Column(unique = true)
     private String name;
+
+    @Setter
+    @Column(nullable = false)
+    boolean isCollege = true;
 
     @OneToMany(mappedBy = "college", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Department> departments = new ArrayList<>();

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/College.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/entity/College.java
@@ -23,8 +23,8 @@ public class College {
     private String name;
 
     @Setter
-    @Column(nullable = false)
-    boolean isCollege = true;
+    @Column(name = "is_college", nullable = false)
+    private boolean college = true;
 
     @OneToMany(mappedBy = "college", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Department> departments = new ArrayList<>();

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/CollegeRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/CollegeRepository.java
@@ -4,9 +4,13 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CollegeRepository extends JpaRepository<College, Long> {
     Optional<College> findByName(String name);
+
+    List<College> findAllByCollegeTrue();
+    List<College> findAllByCollegeFalse();
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/DevPublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/DevPublicFolderService.java
@@ -1,0 +1,23 @@
+package gnu.capstone.G_Learn_E.domain.public_folder.service;
+
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
+import gnu.capstone.G_Learn_E.domain.public_folder.repository.CollegeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DevPublicFolderService {
+
+    private final CollegeRepository collegeRepository;
+
+    @Transactional
+    public College updateIsCollege(Long collegeId, boolean isCollege) {
+        College college = collegeRepository.findById(collegeId).orElseThrow(() -> new RuntimeException("College not found"));
+        college.setCollege(isCollege);
+        return collegeRepository.save(college);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -31,6 +31,13 @@ public class PublicFolderService {
     public List<College> getColleges() {
         return collegeRepository.findAll();
     }
+    public List<College> getColleges(boolean isCollege) {
+        if (isCollege) {
+            return collegeRepository.findAllByCollegeTrue();
+        } else {
+            return collegeRepository.findAllByCollegeFalse();
+        }
+    }
 
     public List<Department> getDepartmentsByCollegeId(Long collegeId) {
         return departmentRepository.findByCollegeId(collegeId);

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -28,6 +28,12 @@ public class PublicFolderService {
     private final WorkbookRepository workbookRepository;
 
     // TODO : 커리큘럼 폴더 서비스 구현
+
+    public College getCollege(Long collegeId) {
+        return collegeRepository.findById(collegeId)
+                .orElseThrow(() -> new RuntimeException("College not found"));
+    }
+
     public List<College> getColleges() {
         return collegeRepository.findAll();
     }
@@ -39,6 +45,10 @@ public class PublicFolderService {
         }
     }
 
+    public Department getDepartmentByCollegeId(Long collegeId, Long departmentId) {
+        return departmentRepository.findByIdAndCollegeId(departmentId, collegeId)
+                .orElseThrow(() -> new RuntimeException("Department not found"));
+    }
     public List<Department> getDepartmentsByCollegeId(Long collegeId) {
         return departmentRepository.findByCollegeId(collegeId);
     }
@@ -70,5 +80,4 @@ public class PublicFolderService {
     public boolean isPublicWorkbook(Long workbookId) {
         return subjectWorkbookMapRepository.existsByWorkbook_Id(workbookId);
     }
-
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -1,5 +1,9 @@
 package gnu.capstone.G_Learn_E.domain.user.controller;
 
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
+import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
+import gnu.capstone.G_Learn_E.domain.user.dto.request.AffiliationUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.GainExpRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.NicknameUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.UserInfoResponse;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final PublicFolderService publicFolderService;
 
     @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다.")
     @GetMapping
@@ -52,4 +57,16 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "닉네임이 변경되었습니다.", response);
     }
 
+    @PatchMapping("/affiliation")
+    public ApiResponse<UserInfoResponse> updateAffiliation(
+            @AuthenticationPrincipal User user,
+            @RequestBody AffiliationUpdateRequest request
+    ) {
+        College college = publicFolderService.getCollege(request.collegeId());
+        Department department = publicFolderService.getDepartmentByCollegeId(request.collegeId(), request.departmentId());
+
+        user = userService.updateAffiliation(user, college, department);
+        UserInfoResponse response = UserInfoResponse.from(user);
+        return new ApiResponse<>(HttpStatus.OK, "소속이 변경되었습니다.", response);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/request/AffiliationUpdateRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/request/AffiliationUpdateRequest.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.request;
+
+public record AffiliationUpdateRequest(
+        Long collegeId,
+        Long departmentId
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserInfoResponse.java
@@ -1,5 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.user.dto.response;
 
+import gnu.capstone.G_Learn_E.domain.public_folder.dto.response.CollegeResponse;
+import gnu.capstone.G_Learn_E.domain.public_folder.dto.response.DepartmentResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 
 public record UserInfoResponse(
@@ -8,7 +10,9 @@ public record UserInfoResponse(
         String nickname,
         Integer profileImage,
         Short level,
-        Integer exp
+        Integer exp,
+        CollegeResponse college,
+        DepartmentResponse department
 ) {
     public static UserInfoResponse from(User user) {
         return new UserInfoResponse(
@@ -17,7 +21,9 @@ public record UserInfoResponse(
                 user.getNickname(),
                 user.getProfileImage(),
                 user.getLevel(),
-                user.getExp()
+                user.getExp(),
+                CollegeResponse.from(user.getCollege()),
+                DepartmentResponse.from(user.getDepartment())
         );
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -44,10 +44,12 @@ public class User {
 
     private UserStatus status;
 
+    @Setter
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "college_id", nullable = false)
     private College college;
 
+    @Setter
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "department_id", nullable = false)
     private Department department;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -44,11 +44,11 @@ public class User {
 
     private UserStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "college_id", nullable = false)
     private College college;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "department_id", nullable = false)
     private Department department;
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package gnu.capstone.G_Learn_E.domain.user.entity;
 
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.notification.entity.Notification;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.global.common.enums.UserStatus;
 import jakarta.persistence.*;
@@ -42,6 +44,15 @@ public class User {
 
     private UserStatus status;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "college_id", nullable = false)
+    private College college;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id", nullable = false)
+    private Department department;
+
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Folder> folders = new ArrayList<>();
 
@@ -52,7 +63,7 @@ public class User {
     private List<SolvedWorkbook> solvedWorkbooks = new ArrayList<>();
 
     @Builder
-    public User(String name, String nickname, String email, String password) {
+    public User(String name, String nickname, String email, String password, College college, Department department) {
         this.name = name;
         this.nickname = nickname;
         this.email = email;
@@ -61,6 +72,8 @@ public class User {
         this.level = 1;
         this.exp = 0;
         this.status = UserStatus.ACTIVE;
+        this.college = college;
+        this.department = department;
     }
 
     public void updateProfileImage(Integer profileImage){

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -2,6 +2,8 @@ package gnu.capstone.G_Learn_E.domain.user.service;
 
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.folder.repository.FolderRepository;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserInvalidException;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserNotFoundException;
@@ -27,7 +29,7 @@ public class UserService {
     public User save(User user) {
         return userRepository.save(user);
     }
-    public User save(String name, String nickname, String email, String password) {
+    public User save(String name, String nickname, String email, String password, College college, Department department) {
         if(existsByEmail(email)) {
             throw UserInvalidException.existsEmail();
         }
@@ -40,6 +42,8 @@ public class UserService {
                 .nickname(nickname)
                 .email(email)
                 .password(passwordEncoder.encode(password))
+                .college(college)
+                .department(department)
                 .build();
         user = userRepository.save(user);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -56,6 +56,16 @@ public class UserService {
         return user;
     }
 
+    @Transactional
+    public User updateAffiliation(User user, College college, Department department) {
+        if(!college.isCollege()){
+            throw new RuntimeException("유효한 단과대학이 아닙니다.");
+        }
+        user.setCollege(college);
+        user.setDepartment(department);
+        return userRepository.save(user);
+    }
+
 
     // find --------------------------------------------------------------------------------------------
     public User findById(Long id) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/controller/AuthController.java
@@ -1,5 +1,8 @@
 package gnu.capstone.G_Learn_E.global.auth.controller;
 
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
+import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
+import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
 import gnu.capstone.G_Learn_E.global.auth.dto.request.EmailAuthCodeVerify;
@@ -32,6 +35,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserService userService;
+    private final PublicFolderService publicFolderService;
     private final AuthService authService;
     private final EmailValidator emailValidator;
     private final EmailSender emailSender;
@@ -61,6 +65,11 @@ public class AuthController {
         String nickname = dto.nickname();
         String email = dto.email();
         String password = dto.password();
+        Long collegeId = dto.collegeId();
+        Long departmentId = dto.departmentId();
+
+        College college = publicFolderService.getCollege(collegeId);
+        Department department = publicFolderService.getDepartmentByCollegeId(collegeId, departmentId);
 
         // 토큰 이메일과 입력받은 이메일 검증
         String tokenEmail = (String) request.getAttribute("email");
@@ -69,7 +78,7 @@ public class AuthController {
             throw AuthInvalidException.emailAndTokenNotMatch();
         }
 
-        User savedUser = userService.save(name, nickname, email, password);
+        User savedUser = userService.save(name, nickname, email, password, college, department);
 
         String emailAuthToken = jwtService.extractToken(request);
         jwtService.setBlacklistToken(emailAuthToken);

--- a/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/SignupRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/auth/dto/request/SignupRequest.java
@@ -23,6 +23,8 @@ public record SignupRequest(
                 regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=])[A-Za-z\\d!@#$%^&*()_+\\-=]{8,20}$",
                 message = "비밀번호는 8~20자, 영문+숫자+특수문자를 포함해야 합니다."
         )
-        String password
+        String password,
+        Long collegeId,
+        Long departmentId
 ) {
 }


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#58

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->

- 회원가입 시 단과대 및 학과 정보 기입 기능 추가
- 유저 소속 정보(단과대, 학과) 업데이트 API 추가
- 유저 조회 시 소속 정보 포함 응답
- 단과대 여부 필터링 조회 API 구현
- 단과대의 isCollege 필드 업데이트 API 구현
- 관련 엔티티 및 DTO 필드/로직 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링

## 📝 상세 설명(Details)

1. **회원가입 시 단과대 및 학과 정보 기입 기능 추가**
   - `SignupRequest` DTO에 `collegeId`, `departmentId` 필드 추가
   - `AuthController`에서 `UserService.save()` 호출 시 단과대/학과 엔티티를 함께 저장하도록 수정

2. **유저 소속 정보 업데이트 API 추가**
   - `UserController`에 `/user/affiliation` PATCH API 추가
   - `UserService`에 `updateAffiliation()` 로직 구현
   - 유효하지 않은 단과대에 대한 예외 처리 포함

3. **유저 조회 시 소속 정보 포함**
   - `UserInfoResponse` DTO에 `college`, `department` 필드 추가
   - `from(User user)` 메서드에서 소속 정보도 포함하여 응답

4. **단과대 여부 필터링 조회 API 구현**
   - `PublicFolderController.getColleges()` API에 `@RequestParam isCollege` 추가
   - `CollegeRepository`에서 `findAllByCollegeTrue()`, `findAllByCollegeFalse()` 메서드 구현

5. **단과대의 isCollege 업데이트 API 구현**
   - 개발자용 `DevPublicFolderController`에서 PATCH API 제공
   - `DevPublicFolderService`에서 isCollege 값 업데이트 로직 수행

6. **관련 엔티티 및 DTO 수정**
   - `User`, `College`, `Department` 엔티티에 관계 및 필드 추가
   - `AffiliationUpdateRequest`, `UpdateCollege` 등 신규 DTO 정의
   - `College` 엔티티에 `college` (boolean) 필드 추가 및 setter 제공

## 📸스크린샷 (선택)
(없음)

## 💬 공유사항 to 리뷰어
- `isCollege` 명칭이 Boolean 필드로서 적절한지 검토 부탁드립니다.
- User 관련 로직에서 소속 정보 처리 방식에 대한 개선 아이디어가 있다면 공유해 주세요.
