### PR TITLE
[Feat #61] 문제집 정보 및 문제 수정 기능 구현

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemWorkbookMapRepository.java
@@ -2,17 +2,16 @@ package gnu.capstone.G_Learn_E.domain.problem.repository;
 
 import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ProblemWorkbookMapRepository
         extends JpaRepository<ProblemWorkbookMap, Long> {
 
-    /**
-     * workbook.id 를 기준으로
-     * problemNumber 순 정렬된 매핑 엔티티 리스트를 가져옵니다.
-     */
-    List<ProblemWorkbookMap> findAllByWorkbook_IdOrderByProblemNumber(Long workbookId);
+    @Modifying(clearAutomatically = true)          // flush + 1차캐시 sync
+    @Query("DELETE FROM ProblemWorkbookMap m WHERE m.workbook.id = :wbId")
+    void deleteByWorkbookId(@Param("wbId") Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/controller/SolveLogController.java
@@ -3,7 +3,9 @@ package gnu.capstone.G_Learn_E.domain.solve_log.controller;
 import gnu.capstone.G_Learn_E.domain.folder.service.FolderService;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
@@ -16,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -41,11 +45,12 @@ public class SolveLogController {
                 !publicFolderService.isPublicWorkbook(workbookId)) {
             throw new RuntimeException("문제집 접근 권한이 없습니다.");
         }
+        List<SolveLog> solveLogs = solveLogService.findAllSolveLog(SolvedWorkbookId.builder()
+                        .userId(user.getId())
+                        .workbookId(workbookId)
+                .build());
 
-        Workbook workbook = workbookService.findWorkbookById(workbookId);
-        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
-
-        solveLogService.updateSolveLog(solvedWorkbook, request);
+        solveLogService.updateSolveLog(solveLogs, request);
 
         return new ApiResponse<>(HttpStatus.OK, "풀이 로그 저장 성공", null);
     }
@@ -62,7 +67,7 @@ public class SolveLogController {
         }
 
         Workbook workbook = workbookService.findWorkbookById(workbookId);
-        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbookByIdWithSolveLogs(workbook, user);
 
         solveLogService.deleteAllSolveLog(solvedWorkbook);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbookId.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbookId.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 @Getter
 @Setter
 @Embeddable
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolveLogRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolveLogRepository.java
@@ -1,6 +1,8 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.repository;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +13,6 @@ import java.util.List;
 public interface SolveLogRepository extends JpaRepository<SolveLog, Long> {
 
     List<SolveLog> findAllBySolvedWorkbookId(SolvedWorkbookId solvedWorkbook_id);
+
+    List<SolveLog> findBySolvedWorkbookAndProblemIn(SolvedWorkbook solvedWorkbook, List<Problem> problems);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
@@ -2,9 +2,31 @@ package gnu.capstone.G_Learn_E.domain.solve_log.repository;
 
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface SolvedWorkbookRepository extends JpaRepository<SolvedWorkbook, SolvedWorkbookId> {
+public interface SolvedWorkbookRepository
+        extends JpaRepository<SolvedWorkbook, SolvedWorkbookId> {
+
+    /**
+     * 기본 findById 메서드를 오버라이드하되,
+     * EntityGraph를 붙여 solveLogs만 즉시 로딩하도록 합니다.
+     */
+    @Override
+    @EntityGraph(attributePaths = "solveLogs")
+    Optional<SolvedWorkbook> findById(SolvedWorkbookId id);
+
+
+    /**
+     * 문제집 ID로 푼 문제집을 찾습니다.
+     * @param workbookId 문제집 ID
+     * @return 푼 문제집
+     */
+    @EntityGraph(attributePaths = "solveLogs")
+    List<SolvedWorkbook> findAllByWorkbookId(Long workbookId);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -3,7 +3,6 @@ package gnu.capstone.G_Learn_E.domain.solve_log.service;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
-import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemWorkbookMapRepository;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
@@ -38,33 +37,70 @@ public class SolveLogService {
 
     private final SolveLogRepository solveLogRepository;
     private final SolvedWorkbookRepository solvedWorkbookRepository;
-    private final ProblemWorkbookMapRepository problemWorkbookMapRepository;
     private final FastApiService fastApiService;
 
     // TODO : 풀이 로그 서비스 구현
 
+    public SolvedWorkbook findSolvedWorkbookByIdWithSolveLogs(Workbook workbook, User user) {
+        return solvedWorkbookRepository.findById(
+                        new SolvedWorkbookId(user.getId(), workbook.getId()))
+                .orElseThrow(() -> new RuntimeException("SolvedWorkbook not found"));
+    }
+
     @Transactional
-    public SolvedWorkbook findSolvedWorkbook(Workbook workbook, User user) {
+    public SolvedWorkbook findOrCreateSolvedWorkbook(Workbook workbook, User user) {
         return solvedWorkbookRepository.findById(new SolvedWorkbookId(user.getId(), workbook.getId())).orElseGet(
-                () -> createSolveLogs(workbook, user) // solvedWorkbookId가 없으면 createSolveLogs 메서드 호출
+                () -> createSolvedWorkbook(workbook, user) // solvedWorkbookId가 없으면 createSolveLogs 메서드 호출
         );
     }
 
+    @Transactional
+    public List<SolveLog> findOrCreateAllSolveLog(SolvedWorkbook solvedWorkbook, List<Problem> problems) {
+        // 1) 기존에 저장된 로그 조회
+        List<SolveLog> existingLogs =
+                solveLogRepository.findBySolvedWorkbookAndProblemIn(solvedWorkbook, problems);
+
+        // 2) 문제 → 로그 매핑
+        Map<Long, SolveLog> logMap = existingLogs.stream()
+                .collect(Collectors.toMap(
+                        log -> log.getProblem().getId(),
+                        Function.identity()
+                ));
+
+        // 3) 결과 리스트 구성
+        List<SolveLog> result = new ArrayList<>();
+        for (Problem p : problems) {
+            SolveLog solveLog = logMap.get(p.getId());
+            if (solveLog == null) {
+                // 4) 없으면 새로 생성
+                log.info("새로운 풀이 로그 생성 : {}", p.getId());
+                solveLog = SolveLog.builder()
+                        .solvedWorkbook(solvedWorkbook)
+                        .problem(p)
+                        .build();
+                solveLog = solveLogRepository.save(solveLog);
+            }
+            result.add(solveLog);
+        }
+
+        return result;
+    }
+
+    public List<SolveLog> findAllSolveLog(SolvedWorkbookId solvedWorkbook) {
+        // 문제 풀이 로그 조회
+        return solveLogRepository.findAllBySolvedWorkbookId(solvedWorkbook);
+    }
     public List<SolveLog> findAllSolveLog(SolvedWorkbook solvedWorkbook) {
+        // 문제 풀이 로그 조회
         return solveLogRepository.findAllBySolvedWorkbookId(solvedWorkbook.getId());
     }
 
-    public Map<Long, SolveLog> findAllSolveLogToMap(SolvedWorkbook solvedWorkbook) {
-        return solveLogRepository.findAllBySolvedWorkbookId(solvedWorkbook.getId())
-                .stream()
-                .collect(Collectors.toMap(SolveLog::getProblemId, Function.identity()));
-    }
-
     @Transactional
-    public SolvedWorkbook createSolveLogs(Workbook workbook, User user) {
+    public SolvedWorkbook createSolvedWorkbook(Workbook workbook, User user) {
+        log.info("createSolvedWorkbook");
         SolvedWorkbookId solvedWorkbookId = new SolvedWorkbookId(user.getId(), workbook.getId());
 
-        SolvedWorkbook solvedWorkbook = solvedWorkbookRepository.findById(solvedWorkbookId)
+        return solvedWorkbookRepository.findById(solvedWorkbookId)
                 .orElseGet(() -> solvedWorkbookRepository.save(
                         SolvedWorkbook.builder()
                                 .id(solvedWorkbookId)
@@ -72,16 +108,6 @@ public class SolveLogService {
                                 .workbook(workbook)
                                 .build()
                 ));
-
-        problemWorkbookMapRepository.findAllByWorkbook_IdOrderByProblemNumber(workbook.getId()).forEach(problem -> {
-            SolveLog solveLog = SolveLog.builder()
-                    .solvedWorkbook(solvedWorkbook)
-                    .problem(problem.getProblem())
-                    .build();
-            solveLogRepository.save(solveLog);
-        });
-
-        return solvedWorkbook;
     }
 
     @Transactional
@@ -91,8 +117,9 @@ public class SolveLogService {
     }
 
     @Transactional
-    public void updateSolveLog(SolvedWorkbook solvedWorkbook, SaveSolveLogRequest request){
-        Map<Long, SolveLog> solveLogToMap = findAllSolveLogToMap(solvedWorkbook);
+    public void updateSolveLog(List<SolveLog> solveLogs, SaveSolveLogRequest request){
+        Map<Long, SolveLog> solveLogToMap = solveLogs.stream()
+                .collect(Collectors.toMap(SolveLog::getProblemId, Function.identity()));
 
         List<SolveLog> logsToUpdate = new ArrayList<>();
 
@@ -101,7 +128,10 @@ public class SolveLogService {
             List<String> newAnswer = solveLogRequest.submitAnswer();
 
             SolveLog solveLog = solveLogToMap.get(problemId);
-            if (solveLog == null) continue;
+            if (solveLog == null) {
+                log.warn("문제 풀이 로그 없음 : {}", problemId);
+                throw new RuntimeException("문제 풀이 로그 없음");
+            }
 
             List<String> currentAnswer = solveLog.getSubmitAnswer();
 
@@ -127,16 +157,26 @@ public class SolveLogService {
     }
 
     @Transactional
+    public void deleteAllLogByWorkbook(Long workbookId) {
+        // 문제집에 속한 풀이 로그 삭제
+        List<SolvedWorkbook> solvedWorkbooks = solvedWorkbookRepository.findAllByWorkbookId(workbookId);
+        for (SolvedWorkbook solvedWorkbook : solvedWorkbooks) {
+            deleteAllSolveLog(solvedWorkbook);
+        }
+    }
+
+    @Transactional
     public GradeWorkbookResponse gradeWorkbook(
             User user,
             Workbook workbook,
             SaveSolveLogRequest request
     ) {
-        // 1. SolvedWorkbook 조회 or 신규 생성
-        SolvedWorkbook solvedWorkbook = findSolvedWorkbook(workbook, user);
+        // 1. SolvedWorkbook 조회 (없으면 오류)
+        SolvedWorkbook solvedWorkbook = findSolvedWorkbookByIdWithSolveLogs(workbook, user);
+        List<SolveLog> solveLogs = solvedWorkbook.getSolveLogs();
 
         // 2. 사용자가 보낸 풀이 저장/업데이트
-        updateSolveLog(solvedWorkbook, request);
+        updateSolveLog(solveLogs, request);
 
         // 3. grading: 문제 목록과 정답 맵 생성
         Map<Long, Problem> problemMap = workbook.getProblemWorkbookMaps().stream()
@@ -144,16 +184,15 @@ public class SolveLogService {
                 .collect(Collectors.toMap(Problem::getId, Function.identity()));
 
         // 4. 채점 수행
-        return gradeAllSolveLog(solvedWorkbook, problemMap);
+        return gradeAllSolveLog(solvedWorkbook, solveLogs, problemMap);
     }
 
     @Transactional
-    public GradeWorkbookResponse gradeAllSolveLog(SolvedWorkbook solvedWorkbook, Map<Long, Problem> problemMap) {
+    public GradeWorkbookResponse gradeAllSolveLog(SolvedWorkbook solvedWorkbook, List<SolveLog> solveLogs, Map<Long, Problem> problemMap) {
         // 문제집 풀이 상태 업데이트 (진행 중)
         // 서술형, 빈칸 등의 채점은 GPT 이용으로 인해 시간이 걸릴 수 있으므로 Flush
         forceSetSolvingStatus(solvedWorkbook, SolvingStatus.IN_PROGRESS);
         try {
-            List<SolveLog> solveLogs = findAllSolveLog(solvedWorkbook);
             Map<Long, SolveLog> blankSolveLogMap = new HashMap<>();
             Map<Long, SolveLog> descriptionSolveLogMap = new HashMap<>();
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -64,7 +64,7 @@ public class WorkbookController {
 
     @Operation(summary = "문제집 이름 변경", description = "문제집 이름을 변경합니다.")
     @PatchMapping("/{workbookId}/rename")
-    private ApiResponse<?> renameWorkbook(
+    public ApiResponse<?> renameWorkbook(
             @AuthenticationPrincipal User user,
             @PathVariable("workbookId") Long workbookId,
             @RequestBody WorkbookRenameRequest request
@@ -76,6 +76,21 @@ public class WorkbookController {
         Workbook workbook = workbookService.renameWorkbook(workbookId, request.newName());
         WorkbookSimpleResponse response = WorkbookSimpleResponse.from(workbook);
         return new ApiResponse<>(HttpStatus.OK, "문제집 이름 변경 성공", response);
+    }
+
+    @PatchMapping("/{workbookId}")
+    public ApiResponse<?> updateWorkbook(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId,
+            @RequestBody WorkbookUpdateRequest request
+    ) {
+        log.info("문제집 수정 요청 : {}", request);
+        if(!folderService.isWorkbookInUserFolder(user, workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
+        Workbook workbook = workbookService.updateWorkbook(workbookId, request);
+        WorkbookSimpleResponse response = WorkbookSimpleResponse.from(workbook);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 정보 수정 성공", response);
     }
 
     /**

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -2,6 +2,7 @@ package gnu.capstone.G_Learn_E.domain.workbook.controller;
 
 import gnu.capstone.G_Learn_E.domain.folder.service.FolderService;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -78,6 +80,7 @@ public class WorkbookController {
         return new ApiResponse<>(HttpStatus.OK, "문제집 이름 변경 성공", response);
     }
 
+    @Operation(summary = "문제집 정보 수정", description = "문제집 정보를 수정합니다.")
     @PatchMapping("/{workbookId}")
     public ApiResponse<?> updateWorkbook(
             @AuthenticationPrincipal User user,
@@ -103,22 +106,30 @@ public class WorkbookController {
             @PathVariable("workbookId") Long workbookId
     ){
         Workbook workbook = workbookService.findWorkbookByIdWithProblems(workbookId);
+        List<ProblemWorkbookMap> problemWorkbookMaps = workbook.getProblemWorkbookMaps();
+        List<Problem> problems = problemWorkbookMaps.stream()
+                .map(ProblemWorkbookMap::getProblem)
+                .toList();
         log.info("문제집 조회 성공 : {}", workbook);
         if(!folderService.isWorkbookInUserFolder(user, workbookId) &&
                 !publicFolderService.isPublicWorkbook(workbookId)) {
             throw new RuntimeException("문제집 접근 권한이 없습니다.");
         }
 
-        SolvedWorkbook solvedWorkbook = solveLogService.findSolvedWorkbook(workbook, user);
+        SolvedWorkbook solvedWorkbook = solveLogService.findOrCreateSolvedWorkbook(workbook, user);
         log.info("문제집 풀이 기록 조회 성공 : {}", solvedWorkbook);
 
-        Map<Long, SolveLog> solveLogToMap = solveLogService.findAllSolveLogToMap(solvedWorkbook);
+        List<SolveLog> solveLogs = solveLogService.findOrCreateAllSolveLog(solvedWorkbook, problems);
+        Map<Long, SolveLog> solveLogToMap = solveLogs.stream().collect(
+                Collectors.toMap(SolveLog::getProblemId, solveLog -> solveLog)
+        );
+
         log.info("문제 풀이 기록 조회 성공 : {}", solveLogToMap);
 
         WorkbookSolveResponse response = WorkbookConverter.convertToWorkbookSolveResponse(
                 workbook,
                 solvedWorkbook,
-                workbook.getProblemWorkbookMaps(),
+                problemWorkbookMaps,
                 solveLogToMap
         );
         log.info("문제 풀이 페이지 로드 성공 : {}", response);
@@ -206,5 +217,40 @@ public class WorkbookController {
         Workbook workbook = workbookService.createWorkbookFromProblems(request.problems(), user);
         WorkbookResponse response = WorkbookResponse.of(workbook);
         return new ApiResponse<>(HttpStatus.OK, "문제집 병합 성공", response);
+    }
+
+    @Operation(summary = "문제집 문제 조회 (문제집 편집용)", description = "문제집의 문제를 조회합니다.")
+    @GetMapping("/{workbookId}/problems")
+    public ApiResponse<?> getProblems(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId
+    ) {
+        log.info("문제집 문제 조회 요청 : {}", workbookId);
+        if(!folderService.isWorkbookInUserFolder(user, workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
+        Workbook workbook = workbookService.findWorkbookByIdWithProblems(workbookId);
+        List<Problem> problems = workbook.getProblemWorkbookMaps().stream()
+                .map(ProblemWorkbookMap::getProblem)
+                .toList();
+        WorkbookMergePageResponse response = WorkbookMergePageResponse.from(problems);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 문제 조회 성공", response);
+    }
+
+    @Operation(summary = "문제집 문제 수정", description = "문제집의 문제를 수정합니다.")
+    @PatchMapping("/{workbookId}/problems")
+    public ApiResponse<?> updateProblems(
+            @AuthenticationPrincipal User user,
+            @PathVariable("workbookId") Long workbookId,
+            @RequestBody WorkbookUpdateProblemsRequest request
+    ) {
+        log.info("문제집 문제 수정 요청 : {}", request);
+        if(!folderService.isWorkbookInUserFolder(user, workbookId)) {
+            throw new RuntimeException("문제집 접근 권한이 없습니다.");
+        }
+        solveLogService.deleteAllLogByWorkbook(workbookId);
+        Workbook workbook = workbookService.replaceProblemsInWorkbook(workbookId, request.problems(), user);
+        WorkbookSimpleResponse response = WorkbookSimpleResponse.from(workbook);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 문제 수정 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpdateProblemsRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpdateProblemsRequest.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+import gnu.capstone.G_Learn_E.domain.problem.dto.request.ProblemRequest;
+
+import java.util.List;
+
+public record WorkbookUpdateProblemsRequest(
+        List<ProblemRequest> problems // 문제 리스트
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpdateRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpdateRequest.java
@@ -1,0 +1,11 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
+
+public record WorkbookUpdateRequest(
+        String name,
+        String professor,
+        String examType,
+        Integer coverImage,
+        Integer courseYear,
+        String semester
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -98,4 +98,20 @@ public class Workbook {
         this.problemWorkbookMaps.add(map);
         problem.getProblemWorkbookMaps().add(map);
     }
+
+    public void updateWorkbook(
+            String name,
+            String professor,
+            ExamType examType,
+            Integer coverImage,
+            Integer courseYear,
+            Semester semester
+    ) {
+        this.name = name;
+        this.professor = professor;
+        this.examType = examType;
+        this.coverImage = coverImage;
+        this.courseYear = courseYear;
+        this.semester = semester;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/Workbook.java
@@ -27,6 +27,7 @@ public class Workbook {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")
     private User author;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/ExamType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/ExamType.java
@@ -6,4 +6,14 @@ public enum ExamType {
     MIDDLE, // 중간고사
     FINAL, // 기말고사
     OTHER // 기타
+    ;
+
+    public static ExamType fromString(String examType) {
+        for (ExamType type : ExamType.values()) {
+            if (type.name().equalsIgnoreCase(examType)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid exam type: " + examType);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/Semester.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/Semester.java
@@ -6,4 +6,14 @@ public enum Semester {
     FALL, // 2학기
     WINTER, // 겨울 계절학기
     OTHER // 기타
+    ;
+
+    public static Semester fromString(String semester) {
+        for (Semester sem : Semester.values()) {
+            if (sem.name().equalsIgnoreCase(semester)) {
+                return sem;
+            }
+        }
+        throw new IllegalArgumentException("Invalid semester: " + semester);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -12,6 +12,7 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.*;
 import gnu.capstone.G_Learn_E.domain.public_folder.repository.SubjectRepository;
 import gnu.capstone.G_Learn_E.domain.public_folder.repository.SubjectWorkbookMapRepository;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.dto.request.WorkbookUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
@@ -291,6 +292,19 @@ public class WorkbookService {
         Workbook workbook = workbookRepository.findById(workbookId)
                 .orElseThrow(() -> new RuntimeException("Workbook not found"));
         workbook.setName(newName);
+        return workbookRepository.save(workbook);
+    }
+
+    public Workbook updateWorkbook(Long workbookId, WorkbookUpdateRequest request) {
+        Workbook workbook = findWorkbookById(workbookId);
+        workbook.updateWorkbook(
+                request.name(),
+                request.professor(),
+                ExamType.fromString(request.examType()),
+                request.coverImage(),
+                request.courseYear(),
+                Semester.fromString(request.semester())
+        );
         return workbookRepository.save(workbook);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -170,16 +170,20 @@ public class WorkbookService {
         // 🔹 (c) 다시 매핑
         int seq = 1;
         boolean changed = false;
+        List<Problem> newProblems = new ArrayList<>();
         for (ProblemRequest req : problemRequests) {
             Problem p = existing.get(req.id());
             if (p != null && isEqualProblem(p, req)) {
                 workbook.addProblem(p, seq++);
             } else {
                 Problem newP = ProblemConverter.convertToProblem(req);
-                problemRepository.save(newP);
+                newProblems.add(newP);
                 workbook.addProblem(newP, seq++);
                 changed = true;
             }
+        }
+        if (!newProblems.isEmpty()) {
+            problemRepository.saveAll(newProblems);
         }
         if (changed) workbook.setAuthor(user);
 


### PR DESCRIPTION
## #️⃣ Issue Number
#61

## 📝 요약(Summary)
- `WorkbookController`에 문제집 정보 및 문제 수정 API 추가
- `SolveLogService`에서 문제 비교 및 로그 재생성 로직 수정
- `SolvedWorkbookRepository`에 `EntityGraph`를 적용한 커스텀 조회 메서드 추가
- `WorkbookService`에 문제 수정 및 비교 로직 리팩토링
- 관련 DTO, Enum, Entity에 필드 및 메서드 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 파일 혹은 폴더명 수정

## 📝 상세 설명(Details)

1. **문제집 정보 수정 API 추가**  
   - `WorkbookController`에 `/api/workbook/{workbookId}` 엔드포인트로 PATCH 요청 시 `WorkbookUpdateRequest` 기반으로 문제집의 이름, 교수명, 시험 유형, 표지 이미지, 학년, 학기 정보를 수정하는 기능을 추가했습니다.

2. **문제집 문제 수정 API 추가 및 기존 풀이 로그 삭제 처리**  
   - `WorkbookController`에 `/api/workbook/{workbookId}/problems` 엔드포인트로 PATCH 요청 시 문제 리스트를 수정할 수 있도록 기능을 추가했습니다. 수정 시 기존 문제 풀이 로그를 전부 삭제한 후 새롭게 등록된 문제로 문제집을 구성합니다.

3. **SolveLogService 로직 개선**  
   - 문제와 기존 로그 간 비교를 통해 존재하지 않는 문제 로그는 새롭게 생성하는 로직(`findOrCreateAllSolveLog`)을 도입하였습니다.
   - `updateSolveLog` 메서드는 기존의 `SolvedWorkbook` 기반에서 `List<SolveLog>` 기반으로 변경되며, 성능과 명확성을 개선하였습니다.
   - 채점 로직에서도 `gradeWorkbook` → `gradeAllSolveLog` 로직이 개선되어 solveLog 리스트를 명확히 분리해 처리합니다.

4. **SolvedWorkbookRepository 리팩토링**  
   - `EntityGraph`를 활용해 `solveLogs`를 즉시 로딩하는 커스텀 `findById`, `findAllByWorkbookId` 메서드를 추가하여 N+1 문제를 해결합니다.

5. **WorkbookService 리팩토링 및 비교 로직 분리**  
   - `replaceProblemsInWorkbook`에서 기존 문제와 새로 입력된 문제를 비교 후 동일하면 재활용, 다르면 새로 등록하도록 개선했습니다.
   - `isEqualProblem` 메서드를 도입해 문제의 타입, 제목, 선택지, 정답, 해설까지 세밀히 비교할 수 있도록 했습니다.

6. **DTO 및 ENUM, Entity 기능 추가**  
   - `WorkbookUpdateRequest`, `WorkbookUpdateProblemsRequest` DTO 신설
   - `ExamType`, `Semester` Enum에 fromString() 메서드 추가
   - `Workbook` 엔티티에 `updateWorkbook()` 메서드 추가하여 코드 간결화

## 📸스크린샷 (선택)

(없음)

## 💬 공유사항 to 리뷰어
- 문제 비교 로직의 정확성 및 퍼포먼스를 고려해 `equalsList`, `normalizeBlank` 등의 헬퍼 메서드를 도입했는데, 가독성과 효율성을 높일 수 있는 더 나은 방식이 있다면 의견 부탁드립니다.
- `SolvedWorkbook`과 관련한 캐싱 전략이나 EntityGraph 적용 범위에 대한 추가적인 피드백도 환영합니다.
