### PR TITLE
[Feat #64] Audio To Text 기능 FastAPI와 연동

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 
 import java.text.Normalizer;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/ToStringResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/ToStringResponse.java
@@ -1,6 +1,6 @@
 package gnu.capstone.G_Learn_E.global.fastapi.dto.response;
 
-public record PdfToStringResponse(
+public record ToStringResponse(
         String text
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,8 +41,8 @@ spring:
 
   servlet:
     multipart:
-      max-request-size: 15MB
-      max-file-size: 15MB
+      max-file-size: 100MB
+      max-request-size: 110MB
 
 
 jwt:


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#64

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->

- FastAPI의 Audio To Text 기능을 연동하는 메서드 `audioToStringRequest`가 `FastApiService`에 추가되었습니다.
- 기존 `PdfToStringResponse` 클래스가 `ToStringResponse`로 이름이 변경되면서 범용 응답 DTO로 개선되었습니다.
- application.yml 설정에서 오디오 파일 업로드를 위한 `multipart` 최대 용량이 확대되었습니다.
- 파일명도 `PdfToStringResponse.java`에서 `ToStringResponse.java`로 변경되었습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->

1. `FastApiService` 클래스에 `audioToStringRequest(AudioToStringRequest request)` 메서드를 추가하여, FastAPI 서버의 오디오 인식 API와 연동하도록 구현하였습니다. Multipart 업로드 방식으로 오디오 파일을 전송하며, 응답을 `ToStringResponse`로 받아 텍스트로 변환된 결과를 리턴합니다. 오류 발생 시 로그를 남기고 예외를 던지도록 구성되었습니다.

2. 기존 `PdfToStringResponse` 클래스는 오직 PDF 변환 응답에만 특화되어 있었으나, 이를 `ToStringResponse`로 리네이밍하여 Audio 및 PDF 텍스트 추출 모두에 재사용 가능하도록 구조를 변경하였습니다.

3. FastAPI 요청 처리부에서 클래스명을 `PdfToStringResponse` → `ToStringResponse`로 전환함으로써 코드 일관성을 확보하고, 두 요청(PDF, 오디오)에 동일한 처리 방식을 적용할 수 있게 되었습니다.

4. `application.yml`에서 multipart 업로드 관련 설정값을 수정하였습니다. 오디오 파일의 특성상 용량이 클 수 있으므로, `max-file-size`를 100MB로, `max-request-size`를 110MB로 확장하여 업로드 시 오류를 방지합니다.

## 📸스크린샷 (선택)
(해당 없음)

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
- 메서드 네이밍이나 예외 처리 방식에 대한 피드백 부탁드립니다.
