### PR TITLE
[Feat #63] 유저 통계 및 랭킹 API, 경험치 지급 로직 개선 및 유저 정보 수정 기능 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
@@ -2,6 +2,7 @@ package gnu.capstone.G_Learn_E.domain.solve_log.repository;
 
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
+import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -29,4 +30,13 @@ public interface SolvedWorkbookRepository
      */
     @EntityGraph(attributePaths = "solveLogs")
     List<SolvedWorkbook> findAllByWorkbookId(Long workbookId);
+
+
+    /**
+     * 특정 유저가 완료(COMPLETED)한 SolvedWorkbook 개수를 반환합니다.
+     * @param userId 조회할 유저 ID
+     * @param status 상태 (여기서는 SolvingStatus.COMPLETED)
+     * @return 완료된 워크북 개수
+     */
+    long countByIdUserIdAndStatus(Long userId, SolvingStatus status);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -96,6 +96,18 @@ public class SolveLogService {
     }
 
     @Transactional
+    public boolean updateSolvedWorkbookCountByUser(User user) {
+        // 특정 유저가 완료한 SolvedWorkbook 개수 조회
+        long l = solvedWorkbookRepository.countByIdUserIdAndStatus(user.getId(), SolvingStatus.COMPLETED);
+        if(user.getSolvedWorkbookCount() != l) {
+            // 유저의 SolvedWorkbook 개수 업데이트
+            user.updateSolvedWorkbookCount(l);
+            return true;
+        }
+        return false;
+    }
+
+    @Transactional
     public SolvedWorkbook createSolvedWorkbook(Workbook workbook, User user) {
         log.info("createSolvedWorkbook");
         SolvedWorkbookId solvedWorkbookId = new SolvedWorkbookId(user.getId(), workbook.getId());

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.AffiliationUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.GainExpRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.NicknameUpdateRequest;
+import gnu.capstone.G_Learn_E.domain.user.dto.request.UserInfoUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.*;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
@@ -48,6 +49,20 @@ public class UserController {
         userService.gainExp(user, request.gainExp());
         UserInfoResponse response = UserInfoResponse.from(user);
         return new ApiResponse<>(HttpStatus.OK, "경험치가 증가했습니다.", response);
+    }
+
+    @Operation(summary = "유저 정보 수정", description = "유저 정보를 수정합니다.")
+    @PatchMapping
+    public ApiResponse<UserInfoResponse> updateInfo(
+            @AuthenticationPrincipal User user,
+            @RequestBody UserInfoUpdateRequest request
+    ) {
+        College college = publicFolderService.getCollege(request.collegeId());
+        Department department = publicFolderService.getDepartmentByCollegeId(request.collegeId(), request.departmentId());
+
+        user = userService.updateUserInfo(user, request.name(), request.nickname(), college, department);
+        UserInfoResponse response = UserInfoResponse.from(user);
+        return new ApiResponse<>(HttpStatus.OK, "유저 정보 수정 성공", response);
     }
 
     @Operation(summary = "유저 닉네임 변경", description = "유저의 닉네임을 변경합니다.")

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -104,7 +104,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "유저 정보 조회 성공", response);
     }
 
-    @Operation(summary = "유저 랭킹 조회", description = "유저 랭킹을 조회합니다.")
+    @Operation(summary = "유저 랭킹 조회", description = "유저 랭킹을 조회합니다. 정렬 기준 : level, solvedWorkbookCount, createWorkbookCount")
     @GetMapping("/ranking/user")
     public ApiResponse<?> getRanking(
             @RequestParam(name = "page", defaultValue = "0")
@@ -121,7 +121,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "유저 랭킹 조회 성공", response);
     }
 
-    @Operation(summary = "학과 랭킹 조회", description = "학과 랭킹을 조회합니다.")
+    @Operation(summary = "학과 랭킹 조회", description = "학과 랭킹을 조회합니다. 정렬 기준 : level, solvedWorkbookCount, createWorkbookCount")
     @GetMapping("/ranking/department")
     public ApiResponse<?> getDepartmentRanking(
             @RequestParam(name = "page", defaultValue = "0")
@@ -135,7 +135,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "학과 랭킹 조회 성공", response);
     }
 
-    @Operation(summary = "학과에서 유저 랭킹 조회", description = "학과에서 유저 랭킹을 조회합니다.")
+    @Operation(summary = "학과에서 유저 랭킹 조회", description = "학과에서 유저 랭킹을 조회합니다. 정렬 기준 : level, solvedWorkbookCount, createWorkbookCount")
     @GetMapping("/ranking/department/{departmentId}")
     public ApiResponse<?> getDepartmentRanking(
             @RequestParam(name = "page", defaultValue = "0")
@@ -151,7 +151,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "유저 랭킹 조회 성공", response);
     }
 
-    @Operation(summary = "단과대 랭킹 조회", description = "단과대 랭킹을 조회합니다.")
+    @Operation(summary = "단과대 랭킹 조회", description = "단과대 랭킹을 조회합니다. 정렬 기준 : level, solvedWorkbookCount, createWorkbookCount")
     @GetMapping("/ranking/college")
     public ApiResponse<?> getCollegeRanking(
             @RequestParam(name = "page", defaultValue = "0")
@@ -165,7 +165,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "단과대 랭킹 조회 성공", response);
     }
 
-    @Operation(summary = "단과대에서 유저 랭킹 조회", description = "단과대에서 유저 랭킹을 조회합니다.")
+    @Operation(summary = "단과대에서 유저 랭킹 조회", description = "단과대에서 유저 랭킹을 조회합니다. 정렬 기준 : level, solvedWorkbookCount, createWorkbookCount")
     @GetMapping("/ranking/college/{collegeId}")
     public ApiResponse<?> getCollegeRanking(
             @RequestParam(name = "page", defaultValue = "0")

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -57,6 +57,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "닉네임이 변경되었습니다.", response);
     }
 
+    @Operation(summary = "유저 소속 변경", description = "유저의 소속을 변경합니다.")
     @PatchMapping("/affiliation")
     public ApiResponse<UserInfoResponse> updateAffiliation(
             @AuthenticationPrincipal User user,
@@ -68,5 +69,13 @@ public class UserController {
         user = userService.updateAffiliation(user, college, department);
         UserInfoResponse response = UserInfoResponse.from(user);
         return new ApiResponse<>(HttpStatus.OK, "소속이 변경되었습니다.", response);
+    }
+
+    @GetMapping("/solving-statistics")
+    public ApiResponse<UserInfoResponse> getSolvingStatistics(
+            @AuthenticationPrincipal User user
+    ) {
+        UserInfoResponse response = UserInfoResponse.from(user);
+        return new ApiResponse<>(HttpStatus.OK, "유저 정보 조회 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/CollegeRanking.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/CollegeRanking.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.user.dto;
+
+public record CollegeRanking(
+        Long id,
+        String name,
+        double level,
+        Long createdWorkbooks,
+        Long solvedWorkbooks
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/DepartmentRanking.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/DepartmentRanking.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.user.dto;
+
+public record DepartmentRanking(
+        Long id,
+        String name,
+        double level,
+        Long createdWorkbooks,
+        Long solvedWorkbooks
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/request/UserInfoUpdateRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/request/UserInfoUpdateRequest.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.request;
+
+public record UserInfoUpdateRequest(
+        String name,
+        String nickname,
+        Long collegeId,
+        Long departmentId
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/CollegeRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/CollegeRankingPageResponse.java
@@ -1,0 +1,34 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.response;
+
+import java.util.List;
+
+public record CollegeRankingPageResponse(
+    List<CollegeRankingResponse> rankings
+) {
+
+    public static CollegeRankingPageResponse from(
+            List<CollegeRankingResponse> rankings
+    ) {
+        return new CollegeRankingPageResponse(rankings);
+    }
+
+    public record CollegeRankingResponse(
+            Long id,
+            String name,
+            Long ranking,
+            Long level,
+            Long createdWorkbooks,
+            Long solvedWorkbooks
+    ) {
+        public static CollegeRankingResponse of(
+                Long id,
+                String name,
+                Long ranking,
+                Long level,
+                Long createdWorkbooks,
+                Long solvedWorkbooks
+        ) {
+            return new CollegeRankingResponse(id, name, ranking, level, createdWorkbooks, solvedWorkbooks);
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/DepartmentRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/DepartmentRankingPageResponse.java
@@ -1,0 +1,35 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.response;
+
+import java.util.List;
+
+public record DepartmentRankingPageResponse(
+        List<DepartmentRankingResponse> rankings
+) {
+
+    public static DepartmentRankingPageResponse from(
+            List<DepartmentRankingResponse> rankings
+    ) {
+        return new DepartmentRankingPageResponse(rankings);
+    }
+
+
+    public record DepartmentRankingResponse(
+            Long id,
+            String name,
+            Long ranking,
+            Long level,
+            Long createdWorkbooks,
+            Long solvedWorkbooks
+    ) {
+        public static DepartmentRankingResponse of(
+                Long id,
+                String name,
+                Long ranking,
+                Long level,
+                Long createdWorkbooks,
+                Long solvedWorkbooks
+        ) {
+            return new DepartmentRankingResponse(id, name, ranking, level, createdWorkbooks, solvedWorkbooks);
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserRankingPageResponse.java
@@ -1,0 +1,75 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record UserRankingPageResponse(
+        List<UserRankingResponse> rankings
+) {
+    public static UserRankingPageResponse from(
+            List<User> rankings,
+            long startRank
+    ) {
+        List<UserRankingResponse> list = new ArrayList<>();
+        if (rankings.isEmpty()) {
+            return new UserRankingPageResponse(list);
+        }
+
+        // 첫 유저
+        User first = rankings.get(0);
+        long prevRank  = startRank;
+        short prevLevel = first.getLevel();
+        int prevExp     = first.getExp();
+        int sameCount   = 1;
+
+        list.add(UserRankingResponse.from(first, prevRank));
+
+        // 나머지 유저들: stop-counting 방식
+        for (int i = 1; i < rankings.size(); i++) {
+            User u = rankings.get(i);
+            long rank;
+            if (u.getLevel() == prevLevel && u.getExp() == prevExp) {
+                // 동점: 같은 순위 유지
+                rank = prevRank;
+                sameCount++;
+            } else {
+                // 점수 ↓ : 이전 순위 + 동점자 수
+                rank = prevRank + sameCount;
+                prevLevel = u.getLevel();
+                prevExp   = u.getExp();
+                prevRank  = rank;
+                sameCount = 1;
+            }
+            list.add(UserRankingResponse.from(u, rank));
+        }
+
+        return new UserRankingPageResponse(list);
+    }
+
+    record UserRankingResponse(
+            Long id,
+            String nickname,
+            Integer profileImage,
+            Short level,
+            Long ranking,
+            long createdWorkbooks,
+            long solvedWorkbooks
+    ) {
+        public static UserRankingResponse from(
+                User user,
+                long ranking
+        ) {
+            return new UserRankingResponse(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImage(),
+                    user.getLevel(),
+                    ranking,
+                    user.getCreateWorkbookCount(),
+                    user.getSolvedWorkbookCount()
+            );
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserRankingPageResponse.java
@@ -1,5 +1,7 @@
 package gnu.capstone.G_Learn_E.domain.user.dto.response;
 
+import gnu.capstone.G_Learn_E.domain.public_folder.dto.response.CollegeResponse;
+import gnu.capstone.G_Learn_E.domain.public_folder.dto.response.DepartmentResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 
 import java.util.ArrayList;
@@ -55,7 +57,9 @@ public record UserRankingPageResponse(
             Short level,
             Long ranking,
             long createdWorkbooks,
-            long solvedWorkbooks
+            long solvedWorkbooks,
+            CollegeResponse college,
+            DepartmentResponse department
     ) {
         public static UserRankingResponse from(
                 User user,
@@ -68,7 +72,9 @@ public record UserRankingPageResponse(
                     user.getLevel(),
                     ranking,
                     user.getCreateWorkbookCount(),
-                    user.getSolvedWorkbookCount()
+                    user.getSolvedWorkbookCount(),
+                    CollegeResponse.from(user.getCollege()),
+                    DepartmentResponse.from(user.getDepartment())
             );
         }
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserStatisticsResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserStatisticsResponse.java
@@ -1,0 +1,16 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.response;
+
+public record UserStatisticsResponse(
+        long ranking,
+        long createdWorkbooks,
+        long solvedWorkbooks
+) {
+
+    public static UserStatisticsResponse of(
+            long ranking,
+            long createdWorkbooks,
+            long solvedWorkbooks
+    ) {
+        return new UserStatisticsResponse(ranking, createdWorkbooks, solvedWorkbooks);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -44,7 +44,8 @@ public class User {
 
     private UserStatus status;
 
-    private Integer createWorkbookCount = 0;
+    private long createWorkbookCount;
+    private long solvedWorkbookCount;
 
     @Setter
     @ManyToOne(fetch = FetchType.EAGER)
@@ -79,6 +80,7 @@ public class User {
         this.college = college;
         this.department = department;
         this.createWorkbookCount = 0;
+        this.solvedWorkbookCount = 0;
     }
 
     public void updateProfileImage(Integer profileImage){
@@ -98,5 +100,9 @@ public class User {
 
     public void plusCreateWorkbookCount(){
         this.createWorkbookCount++;
+    }
+
+    public void updateSolvedWorkbookCount(long count){
+        this.solvedWorkbookCount = count;
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -44,6 +44,8 @@ public class User {
 
     private UserStatus status;
 
+    private Integer createWorkbookCount = 0;
+
     @Setter
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "college_id", nullable = false)
@@ -76,6 +78,7 @@ public class User {
         this.status = UserStatus.ACTIVE;
         this.college = college;
         this.department = department;
+        this.createWorkbookCount = 0;
     }
 
     public void updateProfileImage(Integer profileImage){
@@ -91,5 +94,9 @@ public class User {
         if(!UserLevelPolicy.canLevelUp(this.level, this.exp) && this.exp > UserLevelPolicy.getRequiredExp(this.level)){
             this.exp = UserLevelPolicy.getRequiredExp(this.level);
         }
+    }
+
+    public void plusCreateWorkbookCount(){
+        this.createWorkbookCount++;
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -23,6 +23,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/UserLevelPolicy.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/UserLevelPolicy.java
@@ -4,6 +4,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class UserLevelPolicy {
+    // 액션별 고정 XP
+    public static final int EXP_SOLVE_PROBLEM   = 10;
+    public static final int EXP_CREATE_WORKBOOK = 50;
+    public static final int EXP_UPLOAD_WORKBOOK  = 60;
+    public static final int EXP_REVIEW_WORKBOOK = 15;
+    public static final int EXP_RECEIVE_LIKE    = 5;
 
     private static final Map<Integer, Integer> levelExpMap = new HashMap<>();
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/UserLevelPolicy.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/UserLevelPolicy.java
@@ -6,6 +6,7 @@ import java.util.Map;
 public class UserLevelPolicy {
     // 액션별 고정 XP
     public static final int EXP_SOLVE_PROBLEM   = 10;
+    public static final int EXP_RESOLVE_PROBLEM  = 3;
     public static final int EXP_CREATE_WORKBOOK = 50;
     public static final int EXP_UPLOAD_WORKBOOK  = 60;
     public static final int EXP_REVIEW_WORKBOOK = 15;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
@@ -2,9 +2,16 @@ package gnu.capstone.G_Learn_E.domain.user.repository;
 
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookId;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookMap;
+import gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking;
+import gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking;
+import gnu.capstone.G_Learn_E.domain.user.dto.response.DepartmentRankingPageResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.global.common.enums.UserStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,5 +30,136 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
     List<User> findAllByIdIn(List<Long> ids);
 
+
+    /**
+     * 특정 레벨·경험치 기준으로 더 높은 랭킹(레벨이 높거나,
+     * 같은 레벨에서 경험치가 더 많은)인 유저 수를 반환합니다.
+     */
+    @Query("SELECT COUNT(u) FROM User u " +
+            " WHERE u.level > :level " +
+            "    OR (u.level = :level AND u.exp > :exp)")
+    long countHigherRanked(
+            @Param("level") Short level,
+            @Param("exp")   Integer exp
+    );
+
+
+
+    @Query("""
+        SELECT new gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking(
+            u.department.id,
+            u.department.name,
+            AVG(u.level),
+            COUNT(sw),
+            SUM(u.createWorkbookCount)
+        )
+        FROM User u
+        LEFT JOIN u.solvedWorkbooks sw
+        WHERE u.department.college.college = true
+        GROUP BY u.department.id, u.department.name
+        ORDER BY
+          AVG(u.level) DESC
+        """)
+    List<DepartmentRanking> findDepartmentRankingsByLevel(Pageable pageable);
+
+    @Query("""
+        SELECT new gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking(
+            u.department.id,
+            u.department.name,
+            AVG(u.level),
+            COUNT(sw),
+            SUM(u.createWorkbookCount)
+        )
+        FROM User u
+        LEFT JOIN u.solvedWorkbooks sw
+        WHERE u.department.college.college = true
+        GROUP BY u.department.id, u.department.name
+        ORDER BY
+          COUNT(sw) DESC
+        """)
+    List<DepartmentRanking> findDepartmentRankingsByTotalSolved(Pageable pageable);
+
+    @Query("""
+        SELECT new gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking(
+            u.department.id,
+            u.department.name,
+            AVG(u.level),
+            COUNT(sw),
+            SUM(u.createWorkbookCount)
+        )
+        FROM User u
+        LEFT JOIN u.solvedWorkbooks sw
+        WHERE u.department.college.college = true
+        GROUP BY u.department.id, u.department.name
+        ORDER BY
+        SUM(u.createWorkbookCount) DESC
+        """)
+    List<DepartmentRanking> findDepartmentRankingsByTotalCreated(Pageable pageable);
+
+
+
+
+    @Query("""
+        SELECT new gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking(
+            u.college.id,
+            u.college.name,
+            AVG(u.level),
+            COUNT(sw),
+            SUM(u.createWorkbookCount)
+        )
+        FROM User u
+        LEFT JOIN u.solvedWorkbooks sw
+        WHERE u.college.college = true
+        GROUP BY u.college.id, u.college.name
+        ORDER BY
+          AVG(u.level) DESC
+        """)
+    List<CollegeRanking> findCollegeRankingsByLevel(Pageable pageable);
+
+    @Query("""
+        SELECT new gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking(
+            u.college.id,
+            u.college.name,
+            AVG(u.level),
+            COUNT(sw),
+            SUM(u.createWorkbookCount)
+        )
+        FROM User u
+        LEFT JOIN u.solvedWorkbooks sw
+        WHERE u.college.college = true
+        GROUP BY u.college.id, u.college.name
+        ORDER BY
+          COUNT(sw) DESC
+        """)
+    List<CollegeRanking> findCollegeRankingsByTotalSolved(Pageable pageable);
+
+    @Query("""
+        SELECT new gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking(
+            u.college.id,
+            u.college.name,
+            AVG(u.level),
+            COUNT(sw),
+            SUM(u.createWorkbookCount)
+        )
+        FROM User u
+        LEFT JOIN u.solvedWorkbooks sw
+        WHERE u.college.college = true
+        GROUP BY u.college.id, u.college.name
+        ORDER BY
+        SUM(u.createWorkbookCount) DESC
+        """)
+    List<CollegeRanking> findCollegeRankingsByTotalCreated(Pageable pageable);
+
+    Page<User> findByDepartmentIdOrderByLevelDescExpDesc(Long departmentId, Pageable pageable);
+
+    Page<User> findByDepartmentIdOrderBySolvedWorkbookCountDesc(Long departmentId, Pageable pageable);
+
+    Page<User> findByDepartmentIdOrderByCreateWorkbookCountDesc(Long departmentId, Pageable pageable);
+
+    Page<User> findByCollegeIdOrderByLevelDescExpDesc(Long collegeId, Pageable pageable);
+
+    Page<User> findByCollegeIdOrderBySolvedWorkbookCountDesc(Long collegeId, Pageable pageable);
+
+    Page<User> findByCollegeIdOrderByCreateWorkbookCountDesc(Long collegeId, Pageable pageable);
 }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -66,6 +66,12 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    public void plusCreateWorkbookCount(User user) {
+        user.plusCreateWorkbookCount();
+        userRepository.save(user);
+    }
+
+
 
     // find --------------------------------------------------------------------------------------------
     public User findById(Long id) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -4,18 +4,28 @@ import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.folder.repository.FolderRepository;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
+import gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking;
+import gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking;
+import gnu.capstone.G_Learn_E.domain.user.dto.response.CollegeRankingPageResponse;
+import gnu.capstone.G_Learn_E.domain.user.dto.response.DepartmentRankingPageResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserInvalidException;
 import gnu.capstone.G_Learn_E.domain.user.exception.UserNotFoundException;
 import gnu.capstone.G_Learn_E.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -71,6 +81,14 @@ public class UserService {
         userRepository.save(user);
     }
 
+    /**
+     * 특정 유저의 랭킹 계산 (1위 = 1)
+     */
+    public long getUserRank(User user) {
+        long higherCount = userRepository
+                .countHigherRanked(user.getLevel(), user.getExp());
+        return higherCount + 1;
+    }
 
 
     // find --------------------------------------------------------------------------------------------
@@ -117,4 +135,240 @@ public class UserService {
         user.setNickname(newNickname);
         userRepository.save(user);
     }
+
+
+    // ranking --------------------------------------------------------------------------------------
+    public List<User> getUserRankList(int page, int size, String sort) {
+        Sort sortObj;
+        if ("level".equalsIgnoreCase(sort)) {
+            // 레벨 내림차순, 경험치 내림차순
+            sortObj = Sort.by(
+                    Sort.Order.desc("level"),
+                    Sort.Order.desc("exp")
+            );
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            // 푼 워크북 수 내림차순
+            sortObj = Sort.by(
+                    Sort.Order.desc("solvedWorkbookCount")
+            );
+        } else if ("createWorkbook".equalsIgnoreCase(sort)) {
+            // 생성한 워크북 수 내림차순
+            sortObj = Sort.by(
+                    Sort.Order.desc("createWorkbookCount")
+            );
+        } else {
+            throw new RuntimeException("정렬 기준이 잘못되었습니다.");
+        }
+
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+        Page<User> userPage = userRepository.findAll(pageable);
+        return userPage.getContent();
+    }
+
+    public List<User> getUserRankListInDepartment(
+            int page, int size, String sort, Long departmentId
+    ) {
+        // 1) Sort 객체 생성
+        Sort sortObj;
+        if ("level".equalsIgnoreCase(sort)) {
+            sortObj = Sort.by(
+                    Sort.Order.desc("level"),
+                    Sort.Order.desc("exp")
+            );
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            sortObj = Sort.by(
+                    Sort.Order.desc("solvedWorkbookCount")
+            );
+        } else if ("createWorkbook".equalsIgnoreCase(sort)) {
+            sortObj = Sort.by(
+                    Sort.Order.desc("createWorkbookCount")
+            );
+        } else {
+            throw new IllegalArgumentException("정렬 기준이 잘못되었습니다.");
+        }
+
+        // 2) 페이징·정렬 정보
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+
+        // 3) 학과별 분기 호출
+        Page<User> userPage;
+        if ("level".equalsIgnoreCase(sort)) {
+            userPage = userRepository
+                    .findByDepartmentIdOrderByLevelDescExpDesc(departmentId, pageable);
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            userPage = userRepository
+                    .findByDepartmentIdOrderBySolvedWorkbookCountDesc(departmentId, pageable);
+        } else { // createWorkbook
+            userPage = userRepository
+                    .findByDepartmentIdOrderByCreateWorkbookCountDesc(departmentId, pageable);
+        }
+
+        return userPage.getContent();
+    }
+
+    public List<User> getUserRankListInCollege(
+            int page, int size, String sort, Long collegeId
+    ) {
+        // 1) Sort 객체 생성
+        Sort sortObj;
+        if ("level".equalsIgnoreCase(sort)) {
+            sortObj = Sort.by(
+                    Sort.Order.desc("level"),
+                    Sort.Order.desc("exp")
+            );
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            sortObj = Sort.by(
+                    Sort.Order.desc("solvedWorkbookCount")
+            );
+        } else if ("createWorkbook".equalsIgnoreCase(sort)) {
+            sortObj = Sort.by(
+                    Sort.Order.desc("createWorkbookCount")
+            );
+        } else {
+            throw new IllegalArgumentException("정렬 기준이 잘못되었습니다.");
+        }
+
+        // 2) 페이징·정렬 정보
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+
+        // 3) 학과별 분기 호출
+        Page<User> userPage;
+        if ("level".equalsIgnoreCase(sort)) {
+            userPage = userRepository
+                    .findByCollegeIdOrderByLevelDescExpDesc(collegeId, pageable);
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            userPage = userRepository
+                    .findByCollegeIdOrderBySolvedWorkbookCountDesc(collegeId, pageable);
+        } else { // createWorkbook
+            userPage = userRepository
+                    .findByCollegeIdOrderByCreateWorkbookCountDesc(collegeId, pageable);
+        }
+
+        return userPage.getContent();
+    }
+
+    public DepartmentRankingPageResponse getDepartmentRankList(
+            int page,
+            int size,
+            String sort
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        List<DepartmentRanking> rows;
+
+        if ("level".equalsIgnoreCase(sort)) {
+            rows = userRepository.findDepartmentRankingsByLevel(pageable);
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            rows = userRepository.findDepartmentRankingsByTotalSolved(pageable);
+        } else if ("createWorkbook".equalsIgnoreCase(sort)) {
+            rows = userRepository.findDepartmentRankingsByTotalCreated(pageable);
+        } else {
+            throw new RuntimeException("정렬 기준이 잘못되었습니다.");
+        }
+
+        List<DepartmentRankingPageResponse.DepartmentRankingResponse> result = new ArrayList<>();
+        long prevRank   = 0;
+        int  sameCount  = 0;
+        Double prevLvl  = null;
+        Long   prevSolved = null;
+        Long   prevCreated= null;
+
+        for (int i = 0; i < rows.size(); i++) {
+            DepartmentRanking r = rows.get(i);
+            long rank;
+            if (i == 0) {
+                rank = 1;
+                sameCount = 1;
+            } else {
+                boolean same = Objects.equals(r.level(), prevLvl)
+                        && Objects.equals(r.solvedWorkbooks(), prevSolved)
+                        && Objects.equals(r.createdWorkbooks(), prevCreated);
+                if (same) {
+                    rank = prevRank;
+                    sameCount++;
+                } else {
+                    rank = prevRank + sameCount;
+                    sameCount = 1;
+                }
+            }
+            prevRank     = rank;
+            prevLvl      = r.level();
+            prevSolved   = r.solvedWorkbooks();
+            prevCreated  = r.createdWorkbooks();
+
+            result.add(DepartmentRankingPageResponse.DepartmentRankingResponse.of(
+                    r.id(),
+                    r.name(),
+                    rank,
+                    (long) r.level(),
+                    r.solvedWorkbooks(),
+                    r.createdWorkbooks()
+            ));
+        }
+
+        return DepartmentRankingPageResponse.from(result);
+    }
+
+
+    public CollegeRankingPageResponse getCollegeRankList(
+            int page,
+            int size,
+            String sort
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        List<CollegeRanking> rows;
+
+        if ("level".equalsIgnoreCase(sort)) {
+            rows = userRepository.findCollegeRankingsByLevel(pageable);
+        } else if ("solveWorkbook".equalsIgnoreCase(sort)) {
+            rows = userRepository.findCollegeRankingsByTotalSolved(pageable);
+        } else if ("createWorkbook".equalsIgnoreCase(sort)) {
+            rows = userRepository.findCollegeRankingsByTotalCreated(pageable);
+        } else {
+            throw new RuntimeException("정렬 기준이 잘못되었습니다.");
+        }
+
+        List<CollegeRankingPageResponse.CollegeRankingResponse> result = new ArrayList<>();
+        long prevRank   = 0;
+        int  sameCount  = 0;
+        Double prevLvl  = null;
+        Long   prevSolved = null;
+        Long   prevCreated= null;
+
+        for (int i = 0; i < rows.size(); i++) {
+            CollegeRanking r = rows.get(i);
+            long rank;
+            if (i == 0) {
+                rank = 1;
+                sameCount = 1;
+            } else {
+                boolean same = Objects.equals(r.level(), prevLvl)
+                        && Objects.equals(r.solvedWorkbooks(), prevSolved)
+                        && Objects.equals(r.createdWorkbooks(), prevCreated);
+                if (same) {
+                    rank = prevRank;
+                    sameCount++;
+                } else {
+                    rank = prevRank + sameCount;
+                    sameCount = 1;
+                }
+            }
+            prevRank     = rank;
+            prevLvl      = r.level();
+            prevSolved   = r.solvedWorkbooks();
+            prevCreated  = r.createdWorkbooks();
+
+            result.add(CollegeRankingPageResponse.CollegeRankingResponse.of(
+                    r.id(),
+                    r.name(),
+                    rank,
+                    (long) r.level(),
+                    r.solvedWorkbooks(),
+                    r.createdWorkbooks()
+            ));
+        }
+
+        return CollegeRankingPageResponse.from(result);
+    }
+
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
 import gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking;
 import gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking;
+import gnu.capstone.G_Learn_E.domain.user.dto.request.UserInfoUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.CollegeRankingPageResponse;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.DepartmentRankingPageResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
@@ -67,6 +68,33 @@ public class UserService {
     }
 
     @Transactional
+    public User updateUserInfo(User user, String name, String nickname, College college, Department department) {
+        if(userRepository.existsByNickname(nickname)) {
+            // 닉네임 중복 체크
+            throw UserInvalidException.existsNickname();
+        }
+        user.setName(name);
+        user.setNickname(nickname);
+
+        if(!college.isCollege()){
+            throw new RuntimeException("유효한 단과대학이 아닙니다.");
+        }
+        user.setCollege(college);
+        user.setDepartment(department);
+        return userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateNickname(User user, String newNickname) {
+        if(existsByNickname(newNickname)) {
+            // 닉네임 중복 체크
+            throw UserInvalidException.existsNickname();
+        }
+        user.setNickname(newNickname);
+        userRepository.save(user);
+    }
+
+    @Transactional
     public User updateAffiliation(User user, College college, Department department) {
         if(!college.isCollege()){
             throw new RuntimeException("유효한 단과대학이 아닙니다.");
@@ -125,17 +153,6 @@ public class UserService {
         user.gainExp(exp);
         userRepository.save(user);
     }
-
-    @Transactional
-    public void updateNickname(User user, String newNickname) {
-        if(existsByNickname(newNickname)) {
-            // 닉네임 중복 체크
-            throw UserInvalidException.existsNickname();
-        }
-        user.setNickname(newNickname);
-        userRepository.save(user);
-    }
-
 
     // ranking --------------------------------------------------------------------------------------
     public List<User> getUserRankList(int page, int size, String sort) {
@@ -369,6 +386,4 @@ public class UserService {
 
         return CollegeRankingPageResponse.from(result);
     }
-
-
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -7,6 +7,8 @@ import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
+import gnu.capstone.G_Learn_E.domain.user.entity.UserLevelPolicy;
+import gnu.capstone.G_Learn_E.domain.user.service.UserService;
 import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.*;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.*;
@@ -38,6 +40,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class WorkbookController {
 
+    private final UserService userService;
     private final ProblemService problemService;
     private final WorkbookService workbookService;
     private final FolderService folderService;
@@ -57,6 +60,11 @@ public class WorkbookController {
         log.info("Response : {}", problemGenerateResponse);
 
         Workbook workbook = workbookService.createWorkbook(problemGenerateResponse, user);
+
+        // 유저의 문제집 생성 개수 증가
+        userService.plusCreateWorkbookCount(user);
+        // 문제집 생성 시 경험치 부여
+        userService.gainExp(user, UserLevelPolicy.EXP_CREATE_WORKBOOK);
 
         WorkbookResponse response = WorkbookResponse.of(workbook);
 
@@ -149,6 +157,15 @@ public class WorkbookController {
         }
         Workbook workbook = workbookService.findWorkbookByIdWithProblems(workbookId);
         GradeWorkbookResponse response = solveLogService.gradeWorkbook(user, workbook, request);
+
+        userService.gainExp(
+                user,
+                (int) Math.round(
+                        UserLevelPolicy.EXP_SOLVE_PROBLEM
+                                * ((double) response.correctCount()
+                                / (response.correctCount() + response.wrongCount()))
+                )
+        );
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 채점 성공", response);
     }
 
@@ -167,6 +184,7 @@ public class WorkbookController {
                 subject.getId(),
                 subject.getName()
         );
+        userService.gainExp(user, UserLevelPolicy.EXP_UPLOAD_WORKBOOK);
         return new ApiResponse<>(HttpStatus.OK, "문제집 업로드 성공", response);
     }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 
 import java.text.Normalizer;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -185,7 +186,10 @@ public class WorkbookService {
         if (!newProblems.isEmpty()) {
             problemRepository.saveAll(newProblems);
         }
-        if (changed) workbook.setAuthor(user);
+        if (changed){
+            workbook.setAuthor(user);
+            workbook.setUploaded(false);
+        }
 
         return workbook;      // flush 는 트랜잭션 끝에서
     }
@@ -217,6 +221,9 @@ public class WorkbookService {
                 .orElseThrow(() -> new EntityNotFoundException("Subject not found"));
 
         // 2️⃣ 원본 워크북은 업로드 처리만 표시
+        if(origin.isUploaded()) {
+            throw new RuntimeException("이미 업로드된 문제집입니다.");
+        }
         origin.setUploaded(true);   // Dirty-checking으로 자동 update
 
         // 3️⃣ 메타 정보 복제


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#63

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->
- 문제집 풀이 후 경험치 지급 로직 추가 및 중복 풀이 시 경험치 감소 처리
- 유저별 풀이한 문제집 개수 count 로직 추가
- 유저 정보 전체 수정 API 추가
- 유저 통계 및 랭킹 조회 API (유저, 학과, 단과대) 구현
- 랭킹 관련 DTO 및 응답 객체 신설
- 유저 엔티티에 문제집 관련 통계 필드 추가 및 업데이트 로직 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 문서 수정

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->
1. **문제집 풀이 경험치 지급 로직 개선**
   - `WorkbookController`의 채점 로직에서 유저가 이미 푼 문제집일 경우 적은 경험치(EXP_RESOLVE_PROBLEM)를 지급하고, 새로운 풀이일 경우 더 많은 경험치(EXP_SOLVE_PROBLEM)를 지급하도록 처리하였습니다.

2. **유저가 푼 문제집 개수 자동 업데이트**
   - `SolveLogService` 내 `updateSolvedWorkbookCountByUser()` 메서드를 통해 유저가 완료한 문제집 개수를 계산하여 `User` 엔티티의 `solvedWorkbookCount` 필드를 업데이트합니다.

3. **유저 정보 전체 수정 API 구현**
   - `/api/user [PATCH]` 경로를 통해 이름, 닉네임, 단과대, 학과 정보를 한 번에 수정할 수 있는 API가 추가되었습니다.

4. **유저 통계 조회 API 추가**
   - `/api/user/solving-statistics`에서 유저의 랭킹, 생성한 문제집 수, 푼 문제집 수를 조회할 수 있는 API가 구현되었습니다.

5. **유저 랭킹 조회 기능 구현**
   - 유저, 학과, 단과대 랭킹 조회를 위한 API가 각각 구현되었으며, `sort` 파라미터를 통해 정렬 기준을 `level`, `solveWorkbook`, `createWorkbook`으로 선택할 수 있도록 구성되었습니다.

6. **랭킹 응답 객체 및 DTO 구성**
   - `UserRankingPageResponse`, `CollegeRankingPageResponse`, `DepartmentRankingPageResponse` 등의 DTO 및 응답 객체를 통해 랭킹 정보를 일관성 있게 반환할 수 있도록 처리하였습니다.

7. **유저 엔티티 확장 및 통계 필드 추가**
   - `User` 엔티티에 `createWorkbookCount`, `solvedWorkbookCount` 필드가 추가되었고, 이에 따라 생성/풀이 카운팅 로직이 서비스 로직에 반영되었습니다.

## 📸스크린샷 (선택)
(해당 없음)

## 💬 공유사항 to 리뷰어
GET /api/user/rankings
Get /api/user/ranking/department
GET /api/user/ranking/department/{departmentId}
GET /api/user/ranking/college
GET /api/user/ranking/college/{collegeId}
