### PR TITLE
[Feat #72] 공개 문제집 조회 API 및 다운로드 이력 기능 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -6,16 +6,20 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.domain.workbook.service.DownloadedWorkbookService;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @RestController
@@ -25,6 +29,7 @@ import java.util.List;
 public class PublicFolderController {
 
     private final PublicFolderService publicFolderService;
+    private final DownloadedWorkbookService downloadedWorkbookService;
 
 
     @Operation(summary = "단과대 목록 조회", description = "단과대 목록을 조회합니다.")
@@ -64,55 +69,92 @@ public class PublicFolderController {
     @GetMapping("/workbooks/{subject_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooks(@PathVariable("subject_id") Long subjectId) {
         List<Workbook> workbooks = publicFolderService.getWorkbooksBySubjectIdWithAuthor(subjectId);
+        Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(subjectId);
         List<WorkbookResponse> response = workbooks.stream()
-                .map(WorkbookResponse::from)
+                .map(workbook -> WorkbookResponse.from(
+                        workbook,
+                        usersDownloaded.contains(workbook.getId())
+                ))
                 .toList();
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks")
     public ApiResponse<List<WorkbookResponse>> getAllWorkbooks(
+            @AuthenticationPrincipal User user,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
+        List<Workbook> workbooks = publicFolderService.getAllWorkbooks(page, size, sort, order);
+        Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
+        List<WorkbookResponse> response = workbooks.stream()
+                .map(workbook -> WorkbookResponse.from(
+                        workbook,
+                        usersDownloaded.contains(workbook.getId())
+                ))
+                .toList();
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
     }
 
-    @GetMapping("/college/{college_id}/workbooks")
+    @GetMapping("/workbooks/college/{college_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooksByCollegeId(
+            @AuthenticationPrincipal User user,
             @PathVariable("college_id") Long collegeId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-
+        List<Workbook> workbooks = publicFolderService.getAllWorkbooksByCollegeId(collegeId, page, size, sort, order);
+        Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
+        List<WorkbookResponse> response = workbooks.stream()
+                .map(workbook -> WorkbookResponse.from(
+                        workbook,
+                        usersDownloaded.contains(workbook.getId())
+                ))
+                .toList();
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
     }
 
-    @GetMapping("/department/{department_id}/workbooks")
+    @GetMapping("/workbooks/department/{department_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooksByDepartmentId(
+            @AuthenticationPrincipal User user,
             @PathVariable("department_id") Long departmentId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-
+        List<Workbook> workbooks = publicFolderService.getAllWorkbooksByDepartmentId(departmentId, page, size, sort, order);
+        Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
+        List<WorkbookResponse> response = workbooks.stream()
+                .map(workbook -> WorkbookResponse.from(
+                        workbook,
+                        usersDownloaded.contains(workbook.getId())
+                ))
+                .toList();
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
     }
 
-    @GetMapping("/subject/{subject_id}/workbooks")
+    @GetMapping("/workbooks/subject/{subject_id}")
     public ApiResponse<List<WorkbookResponse>> getWorkbooksBySubjectId(
+            @AuthenticationPrincipal User user,
             @PathVariable("subject_id") Long subjectId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-
+        List<Workbook> workbooks = publicFolderService.getAllWorkbooksBySubjectId(subjectId, page, size, sort, order);
+        Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
+        List<WorkbookResponse> response = workbooks.stream()
+                .map(workbook -> WorkbookResponse.from(
+                        workbook,
+                        usersDownloaded.contains(workbook.getId())
+                ))
+                .toList();
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -74,7 +74,8 @@ public class PublicFolderController {
     public ApiResponse<List<WorkbookResponse>> getAllWorkbooks(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
-            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+            @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
+            @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
     }
@@ -84,7 +85,8 @@ public class PublicFolderController {
             @PathVariable("college_id") Long collegeId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
-            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+            @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
+            @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
 
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
@@ -95,7 +97,8 @@ public class PublicFolderController {
             @PathVariable("department_id") Long departmentId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
-            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+            @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
+            @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
 
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
@@ -106,7 +109,8 @@ public class PublicFolderController {
             @PathVariable("subject_id") Long subjectId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
-            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+            @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
+            @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
 
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -69,4 +69,46 @@ public class PublicFolderController {
                 .toList();
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
+
+    @GetMapping("/workbooks")
+    public ApiResponse<List<WorkbookResponse>> getAllWorkbooks(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "25") int size,
+            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+    ) {
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+    }
+
+    @GetMapping("/college/{college_id}/workbooks")
+    public ApiResponse<List<WorkbookResponse>> getWorkbooksByCollegeId(
+            @PathVariable("college_id") Long collegeId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "25") int size,
+            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+    ) {
+
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+    }
+
+    @GetMapping("/department/{department_id}/workbooks")
+    public ApiResponse<List<WorkbookResponse>> getWorkbooksByDepartmentId(
+            @PathVariable("department_id") Long departmentId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "25") int size,
+            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+    ) {
+
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+    }
+
+    @GetMapping("/subject/{subject_id}/workbooks")
+    public ApiResponse<List<WorkbookResponse>> getWorkbooksBySubjectId(
+            @PathVariable("subject_id") Long subjectId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "25") int size,
+            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+    ) {
+
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -95,7 +95,7 @@ public class PublicFolderController {
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
-        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks/college/{college_id}")
@@ -115,7 +115,7 @@ public class PublicFolderController {
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
-        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks/department/{department_id}")
@@ -135,7 +135,7 @@ public class PublicFolderController {
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
-        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks/subject/{subject_id}")
@@ -155,6 +155,6 @@ public class PublicFolderController {
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
-        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", null);
+        return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/WorkbookResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/WorkbookResponse.java
@@ -11,15 +11,17 @@ public record WorkbookResponse(
         String name,
         Integer coverImage,
         LocalDateTime createdAt,
-        Author author
+        Author author,
+        boolean downloaded
 ) {
-    public static WorkbookResponse from(Workbook workbook) {
+    public static WorkbookResponse from(Workbook workbook, boolean downloaded) {
         return new WorkbookResponse(
                 workbook.getId(),
                 workbook.getName(),
                 workbook.getCoverImage(),
                 workbook.getCreatedAt(),
-                Author.from(workbook.getAuthor())
+                Author.from(workbook.getAuthor()),
+                downloaded
         );
     }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/repository/SubjectWorkbookMapRepository.java
@@ -2,6 +2,9 @@ package gnu.capstone.G_Learn_E.domain.public_folder.repository;
 
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookId;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.SubjectWorkbookMap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -11,6 +11,9 @@ import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -79,5 +82,40 @@ public class PublicFolderService {
 
     public boolean isPublicWorkbook(Long workbookId) {
         return subjectWorkbookMapRepository.existsByWorkbook_Id(workbookId);
+    }
+
+
+    public List<Workbook> getAllWorkbooks(int page, int size, String sort, String order) {
+        return workbookRepository.findAllWorkbooks(getPageable(page, size, sort, order)).getContent();
+    }
+
+    public List<Workbook> getAllWorkbooksByCollegeId(Long collegeId, int page, int size, String sort, String order) {
+        return workbookRepository.findAllByCollegeId(collegeId, getPageable(page, size, sort, order)).getContent();
+    }
+
+    public List<Workbook> getAllWorkbooksByDepartmentId(Long departmentId, int page, int size, String sort, String order) {
+        return workbookRepository.findAllByDepartmentId(departmentId, getPageable(page, size, sort, order)).getContent();
+    }
+
+    public List<Workbook> getAllWorkbooksBySubjectId(Long subjectId, int page, int size, String sort, String order) {
+        return workbookRepository.findAllBySubjectId(subjectId, getPageable(page, size, sort, order)).getContent();
+    }
+
+
+    private Pageable getPageable(int page, int size, String sort, String order) {
+        if(!order.equalsIgnoreCase("asc") && !order.equalsIgnoreCase("desc")) {
+            throw new IllegalArgumentException("Invalid order: " + order);
+        }
+        if (page < 0 || size <= 0 || size > 100) {
+            throw new IllegalArgumentException("Invalid page or size: " + page + ", " + size);
+        }
+        if(!sort.equals("createdAt") && !sort.equals("name") && !sort.equals("author")) {
+            throw new IllegalArgumentException("Invalid sort: " + sort);
+        }
+        if(sort.equals("author")) {
+            sort = "author.name";
+        }
+        Sort.Direction direction = order.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        return PageRequest.of(page, size, Sort.by(direction, sort));
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/DownloadedWorkbookMap.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/entity/DownloadedWorkbookMap.java
@@ -1,0 +1,49 @@
+package gnu.capstone.G_Learn_E.domain.workbook.entity;
+
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "downloaded_workbook_map",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_download_user_workbook",
+                columnNames = {"user_id", "workbook_id"}
+        )
+)
+@Getter
+@NoArgsConstructor
+public class DownloadedWorkbookMap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "workbook_id", nullable = false)
+    private Workbook workbook;
+
+    @Column(name = "downloaded_at", nullable = false, updatable = false)
+    private LocalDateTime downloadedAt;
+
+    @PrePersist
+    private void prePersist() {
+        this.downloadedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public DownloadedWorkbookMap(User user, Workbook workbook) {
+        this.user = user;
+        this.workbook = workbook;
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/DownloadedWorkbookMapRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/DownloadedWorkbookMapRepository.java
@@ -1,0 +1,17 @@
+package gnu.capstone.G_Learn_E.domain.workbook.repository;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.DownloadedWorkbookMap;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DownloadedWorkbookMapRepository extends JpaRepository<DownloadedWorkbookMap, Long> {
+
+    boolean existsByUserAndWorkbook(User user, Workbook workbook);
+
+    boolean existsByUserIdAndWorkbookId(Long userId, Long workbookId);
+
+    List<DownloadedWorkbookMap> findAllByUserId(Long userId);
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -39,35 +39,42 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
 
 
 
-    // — 전체
+    /** 전체 워크북 조회 (Subject 매핑만 타고 들어가도록) */
     @EntityGraph(attributePaths = { "author" })
-    @Query("SELECT w FROM Workbook w")
+    @Query("""
+        SELECT DISTINCT w
+          FROM Workbook w
+          JOIN w.subjectWorkbookMaps m
+    """)
     Page<Workbook> findAllWorkbooks(Pageable pageable);
 
-    // — 단과대 기준
+    /** 단과대별 워크북 조회 */
     @EntityGraph(attributePaths = { "author" })
     @Query("""
-        SELECT DISTINCT m.workbook
-          FROM SubjectWorkbookMap m
+        SELECT DISTINCT w
+          FROM Workbook w
+          JOIN w.subjectWorkbookMaps m
          WHERE m.subject.department.college.id = :collegeId
-        """)
+    """)
     Page<Workbook> findAllByCollegeId(@Param("collegeId") Long collegeId, Pageable pageable);
 
-    // — 학과 기준
+    /** 학과별 워크북 조회 */
     @EntityGraph(attributePaths = { "author" })
     @Query("""
-        SELECT DISTINCT m.workbook
-          FROM SubjectWorkbookMap m
+        SELECT DISTINCT w
+          FROM Workbook w
+          JOIN w.subjectWorkbookMaps m
          WHERE m.subject.department.id = :departmentId
-        """)
+    """)
     Page<Workbook> findAllByDepartmentId(@Param("departmentId") Long departmentId, Pageable pageable);
 
-    // — 과목 기준
+    /** 과목별 워크북 조회 */
     @EntityGraph(attributePaths = { "author" })
     @Query("""
-        SELECT m.workbook
-          FROM SubjectWorkbookMap m
+        SELECT DISTINCT w
+          FROM Workbook w
+          JOIN w.subjectWorkbookMaps m
          WHERE m.subject.id = :subjectId
-        """)
+    """)
     Page<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId, Pageable pageable);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -1,6 +1,8 @@
 package gnu.capstone.G_Learn_E.domain.workbook.repository;
 
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -34,4 +36,38 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
           AND w.subjectWorkbookMaps IS EMPTY
     """)
     List<Workbook> findOrphanWorkbooks();
+
+
+
+    // — 전체
+    @EntityGraph(attributePaths = { "author" })
+    @Query("SELECT w FROM Workbook w")
+    Page<Workbook> findAllWorkbooks(Pageable pageable);
+
+    // — 단과대 기준
+    @EntityGraph(attributePaths = { "author" })
+    @Query("""
+        SELECT DISTINCT m.workbook
+          FROM SubjectWorkbookMap m
+         WHERE m.subject.department.college.id = :collegeId
+        """)
+    Page<Workbook> findAllByCollegeId(@Param("collegeId") Long collegeId, Pageable pageable);
+
+    // — 학과 기준
+    @EntityGraph(attributePaths = { "author" })
+    @Query("""
+        SELECT DISTINCT m.workbook
+          FROM SubjectWorkbookMap m
+         WHERE m.subject.department.id = :departmentId
+        """)
+    Page<Workbook> findAllByDepartmentId(@Param("departmentId") Long departmentId, Pageable pageable);
+
+    // — 과목 기준
+    @EntityGraph(attributePaths = { "author" })
+    @Query("""
+        SELECT m.workbook
+          FROM SubjectWorkbookMap m
+         WHERE m.subject.id = :subjectId
+        """)
+    Page<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId, Pageable pageable);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/DownloadedWorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/DownloadedWorkbookService.java
@@ -1,0 +1,28 @@
+package gnu.capstone.G_Learn_E.domain.workbook.service;
+
+import gnu.capstone.G_Learn_E.domain.workbook.repository.DownloadedWorkbookMapRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DownloadedWorkbookService {
+
+    private final DownloadedWorkbookMapRepository downloadedWorkbookMapRepository;
+
+    public boolean isWorkbookDownloaded(Long userId, Long workbookId) {
+        return downloadedWorkbookMapRepository.existsByUserIdAndWorkbookId(userId, workbookId);
+    }
+
+    public Set<Long> getUsersDownloadedWorkbookIds(Long userId) {
+        return downloadedWorkbookMapRepository.findAllByUserId(userId)
+                .stream()
+                .map(downloadedWorkbookMap -> downloadedWorkbookMap.getWorkbook().getId())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -16,9 +16,11 @@ import gnu.capstone.G_Learn_E.domain.public_folder.repository.SubjectWorkbookMap
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.WorkbookUpdateRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.DownloadedWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
 import gnu.capstone.G_Learn_E.domain.workbook.enums.Semester;
+import gnu.capstone.G_Learn_E.domain.workbook.repository.DownloadedWorkbookMapRepository;
 import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
 import gnu.capstone.G_Learn_E.global.common.serialization.Option;
 import jakarta.persistence.EntityNotFoundException;
@@ -48,6 +50,7 @@ public class WorkbookService {
     private final WorkbookRepository workbookRepository;
     private final FolderRepository folderRepository;
     private final FolderWorkbookMapRepository folderWorkbookMapRepository;
+    private final DownloadedWorkbookMapRepository downloadedWorkbookMapRepository;
 
     private static final Normalizer.Form NF = Normalizer.Form.NFC;
 
@@ -295,6 +298,12 @@ public class WorkbookService {
                 .build();
 
         saved.getFolderWorkbookMaps().add(folderWorkbookMap);
+
+        DownloadedWorkbookMap downloadedWorkbookMap = DownloadedWorkbookMap.builder()
+                .user(user)
+                .workbook(origin)
+                .build();
+        downloadedWorkbookMapRepository.save(downloadedWorkbookMap);
 
         // 6️⃣ 저장 — cascade = ALL 덕분에 매핑 엔티티까지 함께 persist
         return saved;


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#72

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->
- 공개 문제집 목록 조회 API 구현 (전체/단과대/학과/과목 기준)
- 사용자가 다운로드한 문제집 여부 반환 로직 추가
- 다운로드 기록 엔티티 및 테이블 정의
- 다운로드 시 기록 저장 로직 추가
- 페이지네이션 및 정렬 기능 추가 지원
- API 반환값 포맷 개선

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->

1. **공개 문제집 조회 API 구현**
   - 전체/단과대/학과/과목 기준으로 문제집을 필터링하여 조회하는 기능 추가.
   - 페이징, 정렬(order, sort) 파라미터를 통해 사용자 편의성 확보.

2. **다운로드 여부 표시 기능**
   - 각 문제집이 사용자가 이미 다운로드한 항목인지 여부를 포함한 `WorkbookResponse` 리팩토링.
   - 클라이언트 측에서 사용성 향상을 위한 UI 구현 가능성 제공.

3. **다운로드 기록 엔티티 및 테이블 추가**
   - `DownloadedWorkbookMap` 엔티티 정의 및 `user_id`, `workbook_id` 복합 유니크 제약 설정.
   - 다운로드 시점 기록(`downloaded_at`) 자동 생성.

4. **다운로드 시 기록 저장 로직 반영**
   - `WorkbookService.downloadWorkbook()` 메서드 내부에서 다운로드 기록 저장 로직 삽입.

5. **페이징 및 정렬 기능 유효성 검사 추가**
   - `PublicFolderService` 내 `getPageable()` 유틸 메서드 구현을 통해 잘못된 값에 대한 예외 처리 수행.

6. **API 반환값 누락 및 조회 오류 수정**
   - 기존 API에서 반환값 일부 누락 및 데이터 조회 문제 해결.

## 📸스크린샷 (선택)
(생략)

## 💬 공유사항 to 리뷰어
