### PR TITLE
[Feat #79] 블랙리스트 시스템 도입 및 Public 조회/랭킹/검색 API에 페이지네이션 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/GLearnEApplication.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/GLearnEApplication.java
@@ -5,12 +5,14 @@ import gnu.capstone.G_Learn_E.global.security.SecurityPathProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
 @EnableScheduling
+@EnableJpaAuditing
 @EnableConfigurationProperties({FastApiProperties.class, SecurityPathProperties.class})
 public class GLearnEApplication {
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -90,7 +90,7 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        WorkbookPaginationResult results = publicFolderService.getAllWorkbooks(page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooks(page, size, sort, order, user);
         List<Workbook> workbooks = results.workbookList();
 
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
@@ -116,7 +116,7 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksByCollegeId(collegeId, page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksByCollegeId(collegeId, page, size, sort, order, user);
         List<Workbook> workbooks = results.workbookList();
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
         List<PublicWorkbook> publicWorkbooks = workbooks.stream()
@@ -141,7 +141,7 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksByDepartmentId(departmentId, page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksByDepartmentId(departmentId, page, size, sort, order, user);
         List<Workbook> workbooks = results.workbookList();
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
         List<PublicWorkbook> publicWorkbooks = workbooks.stream()
@@ -166,7 +166,7 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksBySubjectId(subjectId, page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksBySubjectId(subjectId, page, size, sort, order, user);
         List<Workbook> workbooks = results.workbookList();
 
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/controller/PublicFolderController.java
@@ -9,7 +9,9 @@ import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.service.DownloadedWorkbookService;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
 import gnu.capstone.G_Learn_E.global.common.dto.response.PublicWorkbook;
+import gnu.capstone.G_Learn_E.global.common.dto.serviceToController.WorkbookPaginationResult;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -81,26 +83,32 @@ public class PublicFolderController {
     }
 
     @GetMapping("/workbooks")
-    public ApiResponse<List<PublicWorkbook>> getAllWorkbooks(
+    public ApiResponse<PublicWorkbookSearchResponse> getAllWorkbooks(
             @AuthenticationPrincipal User user,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "25") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        List<Workbook> workbooks = publicFolderService.getAllWorkbooks(page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooks(page, size, sort, order);
+        List<Workbook> workbooks = results.workbookList();
+
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
-        List<PublicWorkbook> response = workbooks.stream()
+        List<PublicWorkbook> publicWorkbooks = workbooks.stream()
                 .map(workbook -> PublicWorkbook.from(
                         workbook,
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
+        PublicWorkbookSearchResponse response = PublicWorkbookSearchResponse.from(
+                results.pageInfo(),
+                publicWorkbooks
+        );
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks/college/{college_id}")
-    public ApiResponse<List<PublicWorkbook>> getWorkbooksByCollegeId(
+    public ApiResponse<PublicWorkbookSearchResponse> getWorkbooksByCollegeId(
             @AuthenticationPrincipal User user,
             @PathVariable("college_id") Long collegeId,
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -108,19 +116,24 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        List<Workbook> workbooks = publicFolderService.getAllWorkbooksByCollegeId(collegeId, page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksByCollegeId(collegeId, page, size, sort, order);
+        List<Workbook> workbooks = results.workbookList();
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
-        List<PublicWorkbook> response = workbooks.stream()
+        List<PublicWorkbook> publicWorkbooks = workbooks.stream()
                 .map(workbook -> PublicWorkbook.from(
                         workbook,
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
+        PublicWorkbookSearchResponse response = PublicWorkbookSearchResponse.from(
+                results.pageInfo(),
+                publicWorkbooks
+        );
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks/department/{department_id}")
-    public ApiResponse<List<PublicWorkbook>> getWorkbooksByDepartmentId(
+    public ApiResponse<PublicWorkbookSearchResponse> getWorkbooksByDepartmentId(
             @AuthenticationPrincipal User user,
             @PathVariable("department_id") Long departmentId,
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -128,19 +141,24 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        List<Workbook> workbooks = publicFolderService.getAllWorkbooksByDepartmentId(departmentId, page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksByDepartmentId(departmentId, page, size, sort, order);
+        List<Workbook> workbooks = results.workbookList();
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
-        List<PublicWorkbook> response = workbooks.stream()
+        List<PublicWorkbook> publicWorkbooks = workbooks.stream()
                 .map(workbook -> PublicWorkbook.from(
                         workbook,
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
+        PublicWorkbookSearchResponse response = PublicWorkbookSearchResponse.from(
+                results.pageInfo(),
+                publicWorkbooks
+        );
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 
     @GetMapping("/workbooks/subject/{subject_id}")
-    public ApiResponse<List<PublicWorkbook>> getWorkbooksBySubjectId(
+    public ApiResponse<PublicWorkbookSearchResponse> getWorkbooksBySubjectId(
             @AuthenticationPrincipal User user,
             @PathVariable("subject_id") Long subjectId,
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -148,14 +166,22 @@ public class PublicFolderController {
             @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
             @RequestParam(value = "order", defaultValue = "desc") String order
     ) {
-        List<Workbook> workbooks = publicFolderService.getAllWorkbooksBySubjectId(subjectId, page, size, sort, order);
+        WorkbookPaginationResult results = publicFolderService.getAllWorkbooksBySubjectId(subjectId, page, size, sort, order);
+        List<Workbook> workbooks = results.workbookList();
+
         Set<Long> usersDownloaded = downloadedWorkbookService.getUsersDownloadedWorkbookIds(user.getId());
-        List<PublicWorkbook> response = workbooks.stream()
+        List<PublicWorkbook> publicWorkbooks = workbooks.stream()
                 .map(workbook -> PublicWorkbook.from(
                         workbook,
                         usersDownloaded.contains(workbook.getId())
                 ))
                 .toList();
+
+        PublicWorkbookSearchResponse response = PublicWorkbookSearchResponse.from(
+                results.pageInfo(),
+                publicWorkbooks
+        );
+
         return new ApiResponse<>(HttpStatus.OK, "문제집 목록 조회 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/PublicWorkbookSearchResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/dto/response/PublicWorkbookSearchResponse.java
@@ -1,0 +1,18 @@
+package gnu.capstone.G_Learn_E.domain.public_folder.dto.response;
+
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PublicWorkbook;
+
+import java.util.List;
+
+public record PublicWorkbookSearchResponse(
+        PageInfo pageInfo,
+        List<PublicWorkbook> publicWorkbooks
+) {
+    public static PublicWorkbookSearchResponse from(
+            PageInfo pageInfo,
+            List<PublicWorkbook> publicWorkbooks
+    ) {
+        return new PublicWorkbookSearchResponse(pageInfo, publicWorkbooks);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -96,8 +96,8 @@ public class PublicFolderService {
     }
 
 
-    public WorkbookPaginationResult getAllWorkbooks(int page, int size, String sort, String order) {
-        Page<Workbook> results = workbookRepository.findAllWorkbooks(getPageable(page, size, sort, order));
+    public WorkbookPaginationResult getAllWorkbooks(int page, int size, String sort, String order, User user) {
+        Page<Workbook> results = workbookRepository.findAllWorkbooks(getPageable(page, size, sort, order), user.getId());
         return WorkbookPaginationResult.from(
                 PageInfo.of(
                         results.getTotalElements(),
@@ -110,8 +110,8 @@ public class PublicFolderService {
         );
     }
 
-    public WorkbookPaginationResult getAllWorkbooksByCollegeId(Long collegeId, int page, int size, String sort, String order) {
-        Page<Workbook> results = workbookRepository.findAllByCollegeId(collegeId, getPageable(page, size, sort, order));
+    public WorkbookPaginationResult getAllWorkbooksByCollegeId(Long collegeId, int page, int size, String sort, String order, User user) {
+        Page<Workbook> results = workbookRepository.findAllByCollegeId(collegeId, getPageable(page, size, sort, order), user.getId());
         return WorkbookPaginationResult.from(
                 PageInfo.of(
                         results.getTotalElements(),
@@ -124,8 +124,8 @@ public class PublicFolderService {
         );
     }
 
-    public WorkbookPaginationResult getAllWorkbooksByDepartmentId(Long departmentId, int page, int size, String sort, String order) {
-        Page<Workbook> results = workbookRepository.findAllByDepartmentId(departmentId, getPageable(page, size, sort, order));
+    public WorkbookPaginationResult getAllWorkbooksByDepartmentId(Long departmentId, int page, int size, String sort, String order, User user) {
+        Page<Workbook> results = workbookRepository.findAllByDepartmentId(departmentId, getPageable(page, size, sort, order), user.getId());
         return WorkbookPaginationResult.from(
                 PageInfo.of(
                         results.getTotalElements(),
@@ -138,8 +138,8 @@ public class PublicFolderService {
         );
     }
 
-    public WorkbookPaginationResult getAllWorkbooksBySubjectId(Long subjectId, int page, int size, String sort, String order) {
-        Page<Workbook> results = workbookRepository.findAllBySubjectId(subjectId, getPageable(page, size, sort, order));
+    public WorkbookPaginationResult getAllWorkbooksBySubjectId(Long subjectId, int page, int size, String sort, String order, User user) {
+        Page<Workbook> results = workbookRepository.findAllBySubjectId(subjectId, getPageable(page, size, sort, order), user.getId());
         return WorkbookPaginationResult.from(
                 PageInfo.of(
                         results.getTotalElements(),

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/public_folder/service/PublicFolderService.java
@@ -11,9 +11,12 @@ import gnu.capstone.G_Learn_E.domain.public_folder.repository.SubjectWorkbookMap
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import gnu.capstone.G_Learn_E.domain.workbook.repository.WorkbookRepository;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
 import gnu.capstone.G_Learn_E.global.common.dto.response.PublicPath;
+import gnu.capstone.G_Learn_E.global.common.dto.serviceToController.WorkbookPaginationResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -93,20 +96,60 @@ public class PublicFolderService {
     }
 
 
-    public List<Workbook> getAllWorkbooks(int page, int size, String sort, String order) {
-        return workbookRepository.findAllWorkbooks(getPageable(page, size, sort, order)).getContent();
+    public WorkbookPaginationResult getAllWorkbooks(int page, int size, String sort, String order) {
+        Page<Workbook> results = workbookRepository.findAllWorkbooks(getPageable(page, size, sort, order));
+        return WorkbookPaginationResult.from(
+                PageInfo.of(
+                        results.getTotalElements(),
+                        results.getTotalPages(),
+                        page,
+                        results.hasNext(),
+                        results.hasPrevious()
+                ),
+                results.getContent()
+        );
     }
 
-    public List<Workbook> getAllWorkbooksByCollegeId(Long collegeId, int page, int size, String sort, String order) {
-        return workbookRepository.findAllByCollegeId(collegeId, getPageable(page, size, sort, order)).getContent();
+    public WorkbookPaginationResult getAllWorkbooksByCollegeId(Long collegeId, int page, int size, String sort, String order) {
+        Page<Workbook> results = workbookRepository.findAllByCollegeId(collegeId, getPageable(page, size, sort, order));
+        return WorkbookPaginationResult.from(
+                PageInfo.of(
+                        results.getTotalElements(),
+                        results.getTotalPages(),
+                        page,
+                        results.hasNext(),
+                        results.hasPrevious()
+                ),
+                results.getContent()
+        );
     }
 
-    public List<Workbook> getAllWorkbooksByDepartmentId(Long departmentId, int page, int size, String sort, String order) {
-        return workbookRepository.findAllByDepartmentId(departmentId, getPageable(page, size, sort, order)).getContent();
+    public WorkbookPaginationResult getAllWorkbooksByDepartmentId(Long departmentId, int page, int size, String sort, String order) {
+        Page<Workbook> results = workbookRepository.findAllByDepartmentId(departmentId, getPageable(page, size, sort, order));
+        return WorkbookPaginationResult.from(
+                PageInfo.of(
+                        results.getTotalElements(),
+                        results.getTotalPages(),
+                        page,
+                        results.hasNext(),
+                        results.hasPrevious()
+                ),
+                results.getContent()
+        );
     }
 
-    public List<Workbook> getAllWorkbooksBySubjectId(Long subjectId, int page, int size, String sort, String order) {
-        return workbookRepository.findAllBySubjectId(subjectId, getPageable(page, size, sort, order)).getContent();
+    public WorkbookPaginationResult getAllWorkbooksBySubjectId(Long subjectId, int page, int size, String sort, String order) {
+        Page<Workbook> results = workbookRepository.findAllBySubjectId(subjectId, getPageable(page, size, sort, order));
+        return WorkbookPaginationResult.from(
+                PageInfo.of(
+                        results.getTotalElements(),
+                        results.getTotalPages(),
+                        page,
+                        results.hasNext(),
+                        results.hasPrevious()
+                ),
+                results.getContent()
+        );
     }
 
     private Pageable getPageable(int page, int size, String sort, String order) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -6,10 +6,12 @@ import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.*;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.*;
+import gnu.capstone.G_Learn_E.global.common.dto.serviceToController.UserPaginationResult;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.entity.UserBlacklist;
 import gnu.capstone.G_Learn_E.domain.user.service.UserBlacklistService;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
 import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -118,9 +120,15 @@ public class UserController {
             @RequestParam(name = "sort", defaultValue = "level")
             String sort
     ) {
-        List<User> rankList = userService.getUserRankList(page, size, sort);
+        UserPaginationResult userPaginationResult = userService.getUserRankList(page, size, sort);
+        List<User> rankList = userPaginationResult.userList();
+        PageInfo pageInfo = userPaginationResult.pageInfo();
 
-        UserRankingPageResponse response = UserRankingPageResponse.from(rankList, userService.getUserRank(rankList.getFirst()));
+        UserRankingPageResponse response = UserRankingPageResponse.from(
+                pageInfo,
+                rankList,
+                userService.getUserRank(rankList.getFirst())
+        );
 
         return new ApiResponse<>(HttpStatus.OK, "유저 랭킹 조회 성공", response);
     }
@@ -150,8 +158,15 @@ public class UserController {
             String sort,
             @PathVariable("departmentId") Long departmentId
     ) {
-        List<User> rankList = userService.getUserRankListInDepartment(page, size, sort, departmentId);
-        UserRankingPageResponse response = UserRankingPageResponse.from(rankList, userService.getUserRank(rankList.getFirst()));
+        UserPaginationResult userPaginationResultInDepartment = userService.getUserRankListInDepartment(page, size, sort, departmentId);
+        List<User> rankList = userPaginationResultInDepartment.userList();
+        PageInfo pageInfo = userPaginationResultInDepartment.pageInfo();
+
+        UserRankingPageResponse response = UserRankingPageResponse.from(
+                pageInfo,
+                rankList,
+                userService.getUserRank(rankList.getFirst())
+        );
         return new ApiResponse<>(HttpStatus.OK, "유저 랭킹 조회 성공", response);
     }
 
@@ -180,8 +195,15 @@ public class UserController {
             String sort,
             @PathVariable("collegeId") Long collegeId
     ) {
-        List<User> rankList = userService.getUserRankListInCollege(page, size, sort, collegeId);
-        UserRankingPageResponse response = UserRankingPageResponse.from(rankList, userService.getUserRank(rankList.getFirst()));
+        UserPaginationResult userPaginationResultInCollege = userService.getUserRankListInCollege(page, size, sort, collegeId);
+        List<User> rankList = userPaginationResultInCollege.userList();
+        PageInfo pageInfo = userPaginationResultInCollege.pageInfo();
+
+        UserRankingPageResponse response = UserRankingPageResponse.from(
+                pageInfo,
+                rankList,
+                userService.getUserRank(rankList.getFirst())
+        );
         return new ApiResponse<>(HttpStatus.OK, "유저 랭킹 조회 성공", response);
     }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -208,7 +208,7 @@ public class UserController {
     }
 
 
-    @Operation(summary = "블랙리스트 조회", description = "블랙리스트를 조회합니다.")
+    @Operation(summary = "블랙리스트 조회", description = "블랙리스트를 조회합니다. 타입 종류 : BLOCK, HIDE")
     @GetMapping("/blacklist")
     public ApiResponse<?> getBlacklist(
             @AuthenticationPrincipal User user,
@@ -223,7 +223,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "블랙리스트 조회 성공", response);
     }
 
-    @Operation(summary = "블랙리스트 추가", description = "블랙리스트에 추가합니다.")
+    @Operation(summary = "블랙리스트 추가", description = "블랙리스트에 추가합니다. 타입 종류 : BLOCK, HIDE")
     @PostMapping("/blacklist")
     public ApiResponse<?> addBlacklist(
             @AuthenticationPrincipal User user,
@@ -233,7 +233,7 @@ public class UserController {
         return new ApiResponse<>(HttpStatus.OK, "블랙리스트 추가 성공", null);
     }
 
-    @Operation(summary = "블랙리스트 삭제", description = "블랙리스트에서 삭제합니다.")
+    @Operation(summary = "블랙리스트 삭제", description = "블랙리스트에서 삭제합니다. 타입 종류 : BLOCK, HIDE")
     @DeleteMapping("/blacklist")
     public ApiResponse<?> removeBlacklist(
             @AuthenticationPrincipal User user,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/request/BlacklistRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/request/BlacklistRequest.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.request;
+
+public record BlacklistRequest(
+        Long targetId,
+        String blacklistType
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/BlacklistResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/BlacklistResponse.java
@@ -1,0 +1,35 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+
+import java.util.List;
+
+public record BlacklistResponse(
+        List<BlacklistUser> blacklistUsers
+) {
+
+    public static BlacklistResponse from(List<User> users) {
+        return new BlacklistResponse(
+                users.stream()
+                        .map(BlacklistUser::from)
+                        .toList()
+        );
+    }
+
+
+    private record BlacklistUser(
+            Long id,
+            String email,
+            String nickname,
+            Integer profileImage
+    ) {
+        public static BlacklistUser from(User user) {
+            return new BlacklistUser(
+                    user.getId(),
+                    user.getEmail(),
+                    user.getNickname(),
+                    user.getProfileImage()
+            );
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/CollegeRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/CollegeRankingPageResponse.java
@@ -1,15 +1,19 @@
 package gnu.capstone.G_Learn_E.domain.user.dto.response;
 
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
+
 import java.util.List;
 
 public record CollegeRankingPageResponse(
+    PageInfo pageInfo,
     List<CollegeRankingResponse> rankings
 ) {
 
     public static CollegeRankingPageResponse from(
+            PageInfo pageInfo,
             List<CollegeRankingResponse> rankings
     ) {
-        return new CollegeRankingPageResponse(rankings);
+        return new CollegeRankingPageResponse(pageInfo, rankings);
     }
 
     public record CollegeRankingResponse(

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/DepartmentRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/DepartmentRankingPageResponse.java
@@ -1,15 +1,19 @@
 package gnu.capstone.G_Learn_E.domain.user.dto.response;
 
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
+
 import java.util.List;
 
 public record DepartmentRankingPageResponse(
+        PageInfo pageInfo,
         List<DepartmentRankingResponse> rankings
 ) {
 
     public static DepartmentRankingPageResponse from(
+            PageInfo pageInfo,
             List<DepartmentRankingResponse> rankings
     ) {
-        return new DepartmentRankingPageResponse(rankings);
+        return new DepartmentRankingPageResponse(pageInfo, rankings);
     }
 
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserRankingPageResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/UserRankingPageResponse.java
@@ -3,20 +3,23 @@ package gnu.capstone.G_Learn_E.domain.user.dto.response;
 import gnu.capstone.G_Learn_E.domain.public_folder.dto.response.CollegeResponse;
 import gnu.capstone.G_Learn_E.domain.public_folder.dto.response.DepartmentResponse;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public record UserRankingPageResponse(
+        PageInfo pageInfo,
         List<UserRankingResponse> rankings
 ) {
     public static UserRankingPageResponse from(
+            PageInfo pageInfo,
             List<User> rankings,
             long startRank
     ) {
         List<UserRankingResponse> list = new ArrayList<>();
         if (rankings.isEmpty()) {
-            return new UserRankingPageResponse(list);
+            return new UserRankingPageResponse(pageInfo, list);
         }
 
         // 첫 유저
@@ -47,7 +50,7 @@ public record UserRankingPageResponse(
             list.add(UserRankingResponse.from(u, rank));
         }
 
-        return new UserRankingPageResponse(list);
+        return new UserRankingPageResponse(pageInfo, list);
     }
 
     record UserRankingResponse(

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -70,6 +70,10 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolvedWorkbook> solvedWorkbooks = new ArrayList<>();
 
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserBlacklist> blacklists = new ArrayList<>();
+
     @Builder
     public User(String name, String nickname, String email, String password, College college, Department department) {
         this.name = name;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/UserBlacklist.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/UserBlacklist.java
@@ -1,0 +1,62 @@
+package gnu.capstone.G_Learn_E.domain.user.entity;
+
+import gnu.capstone.G_Learn_E.domain.user.enums.BlacklistType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "user_blacklist",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "target_user_id"}))
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class UserBlacklist {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_user_id", nullable = false)
+    private User targetUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BlacklistType blacklistType;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public UserBlacklist(User user, User targetUser, BlacklistType blacklistType) {
+        this.user = user;
+        this.targetUser = targetUser;
+        this.blacklistType = blacklistType;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/enums/BlacklistType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/enums/BlacklistType.java
@@ -1,0 +1,6 @@
+package gnu.capstone.G_Learn_E.domain.user.enums;
+
+public enum BlacklistType {
+    BLOCK,
+    HIDE;
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserBlacklistRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserBlacklistRepository.java
@@ -1,0 +1,22 @@
+package gnu.capstone.G_Learn_E.domain.user.repository;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.UserBlacklist;
+import gnu.capstone.G_Learn_E.domain.user.enums.BlacklistType;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserBlacklistRepository extends JpaRepository<UserBlacklist, Long> {
+
+    boolean existsByUserIdAndTargetUserId(Long userId, Long targetId);
+    boolean existsByUserIdAndBlacklistTypeAndTargetUserId(Long userId, BlacklistType blacklistType, Long targetId);
+
+    void deleteByUserIdAndBlacklistTypeAndTargetUserId(Long userId, BlacklistType blacklistType, Long targetId);
+    void deleteByUserIdAndTargetUserId(Long userId, Long targetId);
+
+    @EntityGraph(attributePaths = {
+            "targetUser"
+    })
+    List<UserBlacklist> findAllByUserIdAndBlacklistType(Long userId, BlacklistType blacklistType);
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/UserRepository.java
@@ -60,7 +60,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY
           AVG(u.level) DESC
         """)
-    List<DepartmentRanking> findDepartmentRankingsByLevel(Pageable pageable);
+    Page<DepartmentRanking> findDepartmentRankingsByLevel(Pageable pageable);
 
     @Query("""
         SELECT new gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking(
@@ -77,7 +77,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY
           COUNT(sw) DESC
         """)
-    List<DepartmentRanking> findDepartmentRankingsByTotalSolved(Pageable pageable);
+    Page<DepartmentRanking> findDepartmentRankingsByTotalSolved(Pageable pageable);
 
     @Query("""
         SELECT new gnu.capstone.G_Learn_E.domain.user.dto.DepartmentRanking(
@@ -94,7 +94,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY
         SUM(u.createWorkbookCount) DESC
         """)
-    List<DepartmentRanking> findDepartmentRankingsByTotalCreated(Pageable pageable);
+    Page<DepartmentRanking> findDepartmentRankingsByTotalCreated(Pageable pageable);
 
 
 
@@ -114,7 +114,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY
           AVG(u.level) DESC
         """)
-    List<CollegeRanking> findCollegeRankingsByLevel(Pageable pageable);
+    Page<CollegeRanking> findCollegeRankingsByLevel(Pageable pageable);
 
     @Query("""
         SELECT new gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking(
@@ -131,7 +131,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY
           COUNT(sw) DESC
         """)
-    List<CollegeRanking> findCollegeRankingsByTotalSolved(Pageable pageable);
+    Page<CollegeRanking> findCollegeRankingsByTotalSolved(Pageable pageable);
 
     @Query("""
         SELECT new gnu.capstone.G_Learn_E.domain.user.dto.CollegeRanking(
@@ -148,7 +148,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY
         SUM(u.createWorkbookCount) DESC
         """)
-    List<CollegeRanking> findCollegeRankingsByTotalCreated(Pageable pageable);
+    Page<CollegeRanking> findCollegeRankingsByTotalCreated(Pageable pageable);
 
     Page<User> findByDepartmentIdOrderByLevelDescExpDesc(Long departmentId, Pageable pageable);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserBlacklistService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserBlacklistService.java
@@ -1,0 +1,76 @@
+package gnu.capstone.G_Learn_E.domain.user.service;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.user.entity.UserBlacklist;
+import gnu.capstone.G_Learn_E.domain.user.enums.BlacklistType;
+import gnu.capstone.G_Learn_E.domain.user.repository.UserBlacklistRepository;
+import gnu.capstone.G_Learn_E.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserBlacklistService {
+
+    private final UserRepository userRepository;
+    private final UserBlacklistRepository userBlacklistRepository;
+
+
+    @Transactional
+    public UserBlacklist addBlacklist(User user, Long targetId, String blacklistType) {
+        BlacklistType type = null;
+        if (blacklistType.equals("BLOCK")) {
+            type = BlacklistType.BLOCK;
+        } else if (blacklistType.equals("HIDE")) {
+            type = BlacklistType.HIDE;
+        } else {
+            // 한글로 예외처리
+            throw new IllegalArgumentException("잘못된 블랙리스트 타입입니다.");
+        }
+        if (userBlacklistRepository.existsByUserIdAndTargetUserId(user.getId(), targetId)) {
+            throw new IllegalArgumentException("이미 블랙리스트에 추가된 사용자입니다.");
+        }
+
+        User targetUser = userRepository.findById(targetId).orElseThrow(() -> new IllegalArgumentException("대상 사용자를 찾을 수 없습니다."));
+
+        UserBlacklist userBlacklist = UserBlacklist.builder()
+                .user(user)
+                .targetUser(targetUser)
+                .blacklistType(type)
+                .build();
+
+        return userBlacklistRepository.save(userBlacklist);
+    }
+
+    @Transactional
+    public void removeBlacklist(User user, Long targetId) {
+        if (!userBlacklistRepository.existsByUserIdAndTargetUserId(user.getId(), targetId)) {
+            throw new IllegalArgumentException("블랙리스트에 추가된 사용자가 아닙니다.");
+        }
+        if(!userRepository.existsById(targetId)) {
+            throw new IllegalArgumentException("대상 사용자가 존재하지 않습니다.");
+        }
+
+        userBlacklistRepository.deleteByUserIdAndTargetUserId(user.getId(), targetId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserBlacklist> getBlacklists(User user, String blacklistType) {
+        BlacklistType type = null;
+        if (blacklistType.equals("BLOCK")) {
+            type = BlacklistType.BLOCK;
+        } else if (blacklistType.equals("HIDE")) {
+            type = BlacklistType.HIDE;
+        } else {
+            // 한글로 예외처리
+            throw new IllegalArgumentException("잘못된 블랙리스트 타입입니다.");
+        }
+
+        return userBlacklistRepository.findAllByUserIdAndBlacklistType(user.getId(), type);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.domain.workbook.repository;
 
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,8 +48,13 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long>, JpaSp
         SELECT DISTINCT w
           FROM Workbook w
           JOIN w.subjectWorkbookMaps m
+         WHERE w.author.id NOT IN (
+             SELECT ub.targetUser.id
+               FROM UserBlacklist ub
+              WHERE ub.user.id = :userId
+         )
     """)
-    Page<Workbook> findAllWorkbooks(Pageable pageable);
+    Page<Workbook> findAllWorkbooks(Pageable pageable, @Param("userId") Long userId);
 
     /** 단과대별 워크북 조회 */
     @EntityGraph(attributePaths = { "author" })
@@ -57,8 +63,13 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long>, JpaSp
           FROM Workbook w
           JOIN w.subjectWorkbookMaps m
          WHERE m.subject.department.college.id = :collegeId
+         AND w.author.id NOT IN (
+             SELECT ub.targetUser.id
+               FROM UserBlacklist ub
+              WHERE ub.user.id = :userId
+         )
     """)
-    Page<Workbook> findAllByCollegeId(@Param("collegeId") Long collegeId, Pageable pageable);
+    Page<Workbook> findAllByCollegeId(@Param("collegeId") Long collegeId, Pageable pageable, @Param("userId") Long userId);
 
     /** 학과별 워크북 조회 */
     @EntityGraph(attributePaths = { "author" })
@@ -67,8 +78,13 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long>, JpaSp
           FROM Workbook w
           JOIN w.subjectWorkbookMaps m
          WHERE m.subject.department.id = :departmentId
+         AND w.author.id NOT IN (
+             SELECT ub.targetUser.id
+               FROM UserBlacklist ub
+              WHERE ub.user.id = :userId
+         )
     """)
-    Page<Workbook> findAllByDepartmentId(@Param("departmentId") Long departmentId, Pageable pageable);
+    Page<Workbook> findAllByDepartmentId(@Param("departmentId") Long departmentId, Pageable pageable, @Param("userId") Long userId);
 
     /** 과목별 워크북 조회 */
     @EntityGraph(attributePaths = { "author" })
@@ -77,8 +93,13 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long>, JpaSp
           FROM Workbook w
           JOIN w.subjectWorkbookMaps m
          WHERE m.subject.id = :subjectId
+         AND w.author.id NOT IN (
+             SELECT ub.targetUser.id
+               FROM UserBlacklist ub
+              WHERE ub.user.id = :userId
+         )
     """)
-    Page<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId, Pageable pageable);
+    Page<Workbook> findAllBySubjectId(@Param("subjectId") Long subjectId, Pageable pageable, @Param("userId") Long userId);
 
 
     @EntityGraph(attributePaths = { "author" })

--- a/src/main/java/gnu/capstone/G_Learn_E/global/common/dto/response/PageInfo.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/common/dto/response/PageInfo.java
@@ -1,0 +1,19 @@
+package gnu.capstone.G_Learn_E.global.common.dto.response;
+
+public record PageInfo(
+        Long totalElements,
+        Integer totalPages,
+        Integer pageNumber,
+        boolean hasNextPage,
+        boolean hasPreviousPage
+) {
+    public static PageInfo of(
+            Long totalElements,
+            Integer totalPages,
+            Integer pageNumber,
+            boolean hasNextPage,
+            boolean hasPreviousPage
+    ) {
+        return new PageInfo(totalElements, totalPages, pageNumber, hasNextPage, hasPreviousPage);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/common/dto/serviceToController/UserPaginationResult.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/common/dto/serviceToController/UserPaginationResult.java
@@ -1,0 +1,18 @@
+package gnu.capstone.G_Learn_E.global.common.dto.serviceToController;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
+
+import java.util.List;
+
+public record UserPaginationResult(
+        PageInfo pageInfo,
+        List<User> userList
+) {
+    public static UserPaginationResult from(
+            PageInfo pageInfo,
+            List<User> userList
+    ) {
+        return new UserPaginationResult(pageInfo, userList);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/common/dto/serviceToController/WorkbookPaginationResult.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/common/dto/serviceToController/WorkbookPaginationResult.java
@@ -1,0 +1,18 @@
+package gnu.capstone.G_Learn_E.global.common.dto.serviceToController;
+
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.global.common.dto.response.PageInfo;
+
+import java.util.List;
+
+public record WorkbookPaginationResult(
+        PageInfo pageInfo,
+        List<Workbook> workbookList
+) {
+    public static WorkbookPaginationResult from(
+            PageInfo pageInfo,
+            List<Workbook> workbookList
+    ) {
+        return new WorkbookPaginationResult(pageInfo, workbookList);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/search/dto/response/SearchResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/search/dto/response/SearchResponse.java
@@ -4,21 +4,22 @@ import gnu.capstone.G_Learn_E.domain.folder.dto.response.SimpleFolderResponse;
 import gnu.capstone.G_Learn_E.domain.folder.entity.Folder;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
-import gnu.capstone.G_Learn_E.global.common.dto.response.Author;
-import gnu.capstone.G_Learn_E.global.common.dto.response.PrivateWorkbook;
-import gnu.capstone.G_Learn_E.global.common.dto.response.PublicPath;
-import gnu.capstone.G_Learn_E.global.common.dto.response.PublicWorkbook;
+import gnu.capstone.G_Learn_E.global.common.dto.response.*;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public record SearchResponse(
+        PageInfo privatePageInfo,
         List<SearchedPrivateWorkbook> privateWorkbooks,
+        PageInfo publicPageInfo,
         List<SearchedPublicWorkbook> publicWorkbooks
 ) {
 
     public static SearchResponse from(
+            PageInfo privatePageInfo,
+            PageInfo publicPageInfo,
             List<Workbook> privateWorkbooks,
             Map<Long, Folder> privateWorkbookPaths,
             List<Workbook> publicWorkbooks,
@@ -26,12 +27,14 @@ public record SearchResponse(
             Map<Long, List<PublicPath>> publicWorkbookPaths
     ) {
         return new SearchResponse(
+                privatePageInfo,
                 privateWorkbooks == null ? null :
                         privateWorkbooks.stream()
                                 .map(workbook -> SearchedPrivateWorkbook.from(
                                         workbook, privateWorkbookPaths.get(workbook.getId())
                                 ))
                                 .toList(),
+                publicPageInfo,
                 publicWorkbooks == null ? null :
                         publicWorkbooks.stream()
                                 .map(workbook -> SearchedPublicWorkbook.from(


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#79

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->
- 블랙리스트 시스템(BLOCK, HIDE) 도입 및 API 구현
- Public 문제집 조회 시 차단 유저 필터링 기능 추가
- 모든 목록 및 검색 API에 페이지네이션 정보 포함

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->

1. **블랙리스트 시스템 추가**
   - 유저 간 BLOCK, HIDE 두 가지 타입의 블랙리스트 시스템을 도입하였습니다. (현재는 둘 다 구분 없이 사용)
   - `/api/user/blacklist` API를 통해 블랙리스트 추가/삭제/조회가 가능합니다.
   - 관련 Entity (`UserBlacklist`), DTO (`BlacklistRequest`, `BlacklistResponse`) 및 서비스 레이어 구현이 포함됩니다.

2. **Public 문제집 조회 시 차단 유저 필터링**
   - 블랙리스트 된 유저가 작성한 문제집은 Public 문제집 목록에서 제외됩니다.

3. **페이지네이션 정보 통합**
   - 기존 목록 반환 API(문제집 조회, 랭킹 조회, 검색 결과 등)에 `PageInfo`를 포함한 새로운 응답 구조로 리팩토링되었습니다.
   - 각 응답 DTO(`PublicWorkbookSearchResponse`, `UserRankingPageResponse`, 등)에 `PageInfo`를 포함하여 클라이언트에서 페이지 처리가 가능해졌습니다.

## 📸스크린샷 (선택)
(스크린샷이 있다면 여기에 첨부해주세요)

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
