### PR TITLE
[Feat #83] 문제 키워드 추출 기능 및 유저 오답 기반 통계 API 추가

### DIFF
--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/DevProblemController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/controller/DevProblemController.java
@@ -1,35 +1,39 @@
-package gnu.capstone.G_Learn_E.global.scheduler;
+package gnu.capstone.G_Learn_E.domain.problem.controller;
 
 
+import gnu.capstone.G_Learn_E.domain.problem.dto.request.ExtractKeywordsRequest;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.service.ProblemKeywordService;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.response.ExtractKeywordsResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
+import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @Slf4j
-@Component
+@RestController
+@RequestMapping("/dev/api/problem")
 @RequiredArgsConstructor
-public class KeywordGenerateScheduler {
+public class DevProblemController {
+
     private final FastApiService fastApiService;
     private final ProblemKeywordService problemKeywordService;
 
     @Value("${keywords-per-problem}")
     private int keywordsPerProblem;
 
-    @Scheduled(fixedRate = 60000) // 1분마다 실행
-    public void keywordGenerate() {
+
+    @PostMapping("/extract-keywords")
+    public ApiResponse<?> keywordGenerate(ExtractKeywordsRequest request) {
         // TODO : 예외 발생 시 다음 문제 키워드 추출 안되는 구조 수정해야 함
-        List<Problem> problems = problemKeywordService.findProblemsByProblemKeywordsIsEmpty(0, 5);
-        if(problems.isEmpty()) {
-            return;
-        }
+        List<Problem> problems = problemKeywordService.findProblemsByProblemKeywordsIsEmpty(request.page(), request.size());
         ExtractKeywordsResponse extractKeywordsResponse;
         try {
             extractKeywordsResponse = fastApiService.extractKeywordsFromProblems(problems, keywordsPerProblem);
@@ -50,5 +54,7 @@ public class KeywordGenerateScheduler {
                 throw new RuntimeException("키워드 저장 중 오류가 발생했습니다.");
             }
         }
+        return new ApiResponse<>(HttpStatus.OK, "키워드 추출에 성공하였습니다.", extractKeywordsResponse);
     }
+
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/request/ExtractKeywordsRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/request/ExtractKeywordsRequest.java
@@ -1,0 +1,7 @@
+package gnu.capstone.G_Learn_E.domain.problem.dto.request;
+
+public record ExtractKeywordsRequest(
+        int page,
+        int size
+) {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/KeywordFrequencyResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/dto/response/KeywordFrequencyResponse.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.problem.dto.response;
+
+public record KeywordFrequencyResponse(
+        String keyword,
+        Long count
+) {
+    public static KeywordFrequencyResponse of(String keyword, Long count) {
+        return new KeywordFrequencyResponse(keyword, count);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/FailedKeywordGenerate.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/FailedKeywordGenerate.java
@@ -1,0 +1,26 @@
+package gnu.capstone.G_Learn_E.domain.problem.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FailedKeywordGenerate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long problemId;
+
+     @Builder
+    public FailedKeywordGenerate(Long problemId) {
+         this.problemId = problemId;
+     }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/Problem.java
@@ -45,6 +45,9 @@ public class Problem {
     @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolveLog> solveLogs = new ArrayList<>();
 
+    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProblemKeyword> problemKeywords = new ArrayList<>();
+
     @Builder
     public Problem(String title,
                    List<Option> options,

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/ProblemKeyword.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/entity/ProblemKeyword.java
@@ -1,0 +1,32 @@
+package gnu.capstone.G_Learn_E.domain.problem.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ProblemKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String keyword;
+
+    private int priority;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+
+
+    @Builder
+    public ProblemKeyword(String keyword, int priority, Problem problem) {
+        this.keyword = keyword;
+        this.priority = priority;
+        this.problem = problem;
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/FailedKeywordGenerateRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/FailedKeywordGenerateRepository.java
@@ -1,0 +1,9 @@
+package gnu.capstone.G_Learn_E.domain.problem.repository;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.FailedKeywordGenerate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FailedKeywordGenerateRepository extends JpaRepository<FailedKeywordGenerate, Long> {
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemKeywordRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemKeywordRepository.java
@@ -1,0 +1,10 @@
+package gnu.capstone.G_Learn_E.domain.problem.repository;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProblemKeywordRepository extends JpaRepository<ProblemKeyword, Long> {
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemKeywordRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemKeywordRepository.java
@@ -4,7 +4,10 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProblemKeywordRepository extends JpaRepository<ProblemKeyword, Long> {
 
+    List<ProblemKeyword> findAllByProblem_IdIn(List<Long> problemIds);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
@@ -4,6 +4,7 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +22,9 @@ public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpec
 
     // 문제집 ID 리스트에 속하는 문제 조회
     List<Problem> findAllByProblemWorkbookMaps_Workbook_IdIn(List<Long> workbookIds);
+
+
+    // 랜덤 (임시)
+    @Query(value = "SELECT * FROM problem ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<Problem> findRandomProblems(@Param("limit") int limit);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/repository/ProblemRepository.java
@@ -1,6 +1,8 @@
 package gnu.capstone.G_Learn_E.domain.problem.repository;
 
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +29,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpec
     // 랜덤 (임시)
     @Query(value = "SELECT * FROM problem ORDER BY RAND() LIMIT :limit", nativeQuery = true)
     List<Problem> findRandomProblems(@Param("limit") int limit);
+
+
+    Page<Problem> findByProblemKeywordsIsEmpty(Pageable pageable);
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemKeywordService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemKeywordService.java
@@ -1,0 +1,66 @@
+package gnu.capstone.G_Learn_E.domain.problem.service;
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.FailedKeywordGenerate;
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemKeyword;
+import gnu.capstone.G_Learn_E.domain.problem.repository.FailedKeywordGenerateRepository;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemKeywordRepository;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProblemKeywordService {
+
+    private final ProblemRepository problemRepository;
+    private final ProblemKeywordRepository problemKeywordRepository;
+    private final FailedKeywordGenerateRepository failedKeywordGenerateRepository;
+
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveProblemKeywords(Long problemId, List<String> keywords) {
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new IllegalArgumentException("Problem not found with id: " + problemId));
+
+        AtomicInteger priority = new AtomicInteger(1);
+
+        List<ProblemKeyword> problemKeywords = keywords.stream()
+                .map(keyword -> ProblemKeyword.builder()
+                        .priority(priority.getAndIncrement())
+                        .problem(problem)
+                        .keyword(keyword)
+                        .build())
+                .toList();
+        problemKeywordRepository.saveAll(problemKeywords);
+    }
+
+    public List<Problem> findProblemsByProblemKeywordsIsEmpty(int page, int size) {
+        return problemRepository.findByProblemKeywordsIsEmpty(PageRequest.of(page, size)).getContent();
+    }
+
+    @Transactional
+    public void saveFailedKeywordGenerate(Long problemId) {
+        failedKeywordGenerateRepository.save(FailedKeywordGenerate.builder()
+                .problemId(problemId)
+                .build());
+    }
+
+    @Transactional
+    public void saveFailedKeywordGenerate(List<Long> problemIds) {
+        List<FailedKeywordGenerate> failedKeywordGenerates = problemIds.stream()
+                .map(problemId -> FailedKeywordGenerate.builder()
+                        .problemId(problemId)
+                        .build())
+                .toList();
+        failedKeywordGenerateRepository.saveAll(failedKeywordGenerates);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemKeywordService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/problem/service/ProblemKeywordService.java
@@ -1,11 +1,16 @@
 package gnu.capstone.G_Learn_E.domain.problem.service;
 
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.KeywordFrequencyResponse;
 import gnu.capstone.G_Learn_E.domain.problem.entity.FailedKeywordGenerate;
 import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemKeyword;
 import gnu.capstone.G_Learn_E.domain.problem.repository.FailedKeywordGenerateRepository;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemKeywordRepository;
 import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
+import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
+import gnu.capstone.G_Learn_E.domain.solve_log.repository.SolveLogRepository;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -13,8 +18,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -24,6 +33,8 @@ public class ProblemKeywordService {
     private final ProblemRepository problemRepository;
     private final ProblemKeywordRepository problemKeywordRepository;
     private final FailedKeywordGenerateRepository failedKeywordGenerateRepository;
+
+    private final SolveLogRepository solveLogRepository;
 
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -62,5 +73,43 @@ public class ProblemKeywordService {
                         .build())
                 .toList();
         failedKeywordGenerateRepository.saveAll(failedKeywordGenerates);
+    }
+
+    public List<KeywordFrequencyResponse> getTopWrongKeywords(User user, int topN) {
+        // 1) 완료된 풀로그 전체 조회
+        List<SolveLog> solveLogs = solveLogRepository
+                .findAllCompletedSolveLogs( // 혹은 findAllCompletedSolveLogs
+                        user.getId(),
+                        SolvingStatus.COMPLETED
+                );
+
+        // 2) 오답 문제 ID만 뽑아서 중복 제거
+        List<Long> wrongProblemIds = solveLogs.stream()
+                .filter(sl -> Boolean.FALSE.equals(sl.getIsCorrect()))
+                .map(SolveLog::getProblemId)
+                .distinct()
+                .toList();
+
+        if (wrongProblemIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 3) 해당 문제들의 키워드들 모두 조회
+        List<ProblemKeyword> keywords = problemKeywordRepository
+                .findAllByProblem_IdIn(wrongProblemIds);
+
+        // 4) 키워드별 빈도수 집계
+        Map<String, Long> freqMap = keywords.stream()
+                .collect(Collectors.groupingBy(
+                        ProblemKeyword::getKeyword,
+                        Collectors.counting()
+                ));
+
+        // 5) 빈도 내림차순 정렬 후 상위 N개를 DTO로 변환
+        return freqMap.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder()))
+                .limit(topN)
+                .map(e -> KeywordFrequencyResponse.of(e.getKey(), e.getValue()))
+                .toList();
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/response/SolveLogResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/response/SolveLogResponse.java
@@ -1,6 +1,24 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.dto.response;
 
-public record SolveLogResponse(
+import java.time.LocalDateTime;
 
+public record SolveLogResponse(
+        String status, // NOT_STARTED("기록 없음"),IN_PROGRESS("풀이중"),COMPLETED("채점 완료");
+        LocalDateTime recentDateTime, // 최근 풀이 시간
+        int correctCount, // 정답 수
+        int wrongCount // 오답 수
 ) {
+    public static SolveLogResponse of(
+            String status,
+            LocalDateTime recentDateTime,
+            int correctCount,
+            int wrongCount
+    ) {
+        return new SolveLogResponse(
+                status,
+                recentDateTime,
+                correctCount,
+                wrongCount
+        );
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/response/WorkbookWrongRateResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/dto/response/WorkbookWrongRateResponse.java
@@ -1,0 +1,25 @@
+package gnu.capstone.G_Learn_E.domain.solve_log.dto.response;
+
+public record WorkbookWrongRateResponse(
+        Long   workbookId,
+        String name,
+        double wrongRate,
+        long   wrongCount,
+        long   totalCount
+) {
+    public static WorkbookWrongRateResponse of(
+            Long   workbookId,
+            String name,
+            double wrongRate,
+            long   wrongCount,
+            long   totalCount
+    ) {
+        return new WorkbookWrongRateResponse(
+                workbookId,
+                name,
+                wrongRate,
+                wrongCount,
+                totalCount
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbook.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/entity/SolvedWorkbook.java
@@ -8,10 +8,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
 public class SolvedWorkbook {
@@ -34,6 +39,15 @@ public class SolvedWorkbook {
     @Setter
     @Enumerated(EnumType.STRING)
     private SolvingStatus status; // 풀이 상태 (진행 중, 완료 등)
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // 최종 수정 시각
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
     @Builder
     public SolvedWorkbook(SolvedWorkbookId id, User user, Workbook workbook) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/enums/SolvingStatus.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/enums/SolvingStatus.java
@@ -1,8 +1,17 @@
 package gnu.capstone.G_Learn_E.domain.solve_log.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum SolvingStatus {
 
-    NOT_STARTED,
-    IN_PROGRESS,
-    COMPLETED
+    NOT_STARTED("기록 없음"),
+    IN_PROGRESS("풀이중"),
+    COMPLETED("채점 완료");
+
+    private final String status;
+
+    SolvingStatus(String status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolveLogRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolveLogRepository.java
@@ -4,7 +4,10 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
+import gnu.capstone.G_Learn_E.domain.solve_log.enums.SolvingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +18,16 @@ public interface SolveLogRepository extends JpaRepository<SolveLog, Long> {
     List<SolveLog> findAllBySolvedWorkbookId(SolvedWorkbookId solvedWorkbook_id);
 
     List<SolveLog> findBySolvedWorkbookAndProblemIn(SolvedWorkbook solvedWorkbook, List<Problem> problems);
+
+
+    @Query("""
+        SELECT sl FROM SolveLog sl
+            JOIN FETCH sl.problem p
+        WHERE sl.solvedWorkbook.user.id = :userId
+         AND sl.solvedWorkbook.status = :status
+    """)
+    List<SolveLog> findAllCompletedSolveLogs(
+            @Param("userId") Long userId,
+            @Param("status") SolvingStatus status
+    );
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
@@ -39,4 +39,10 @@ public interface SolvedWorkbookRepository
      * @return 완료된 워크북 개수
      */
     long countByIdUserIdAndStatus(Long userId, SolvingStatus status);
+
+    @EntityGraph(attributePaths = "solveLogs")
+    List<SolvedWorkbook> findAllByUser_IdAndStatus(
+            Long userId,
+            SolvingStatus status
+    );
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/repository/SolvedWorkbookRepository.java
@@ -40,7 +40,10 @@ public interface SolvedWorkbookRepository
      */
     long countByIdUserIdAndStatus(Long userId, SolvingStatus status);
 
-    @EntityGraph(attributePaths = "solveLogs")
+    @EntityGraph(attributePaths = {
+            "solveLogs",
+            "workbook",
+    })
     List<SolvedWorkbook> findAllByUser_IdAndStatus(
             Long userId,
             SolvingStatus status

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -5,6 +5,7 @@ import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemWorkbookMap;
 import gnu.capstone.G_Learn_E.domain.problem.enums.ProblemType;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SolveLogRequest;
+import gnu.capstone.G_Learn_E.domain.solve_log.dto.response.WorkbookWrongRateResponse;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolveLog;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbook;
 import gnu.capstone.G_Learn_E.domain.solve_log.entity.SolvedWorkbookId;
@@ -342,5 +343,38 @@ public class SolveLogService {
                         )
                         .toList());
         return fastApiService.gradeDescriptive(request).result();
+    }
+
+    public List<WorkbookWrongRateResponse> getTopWrongRateWorkbooks(
+            User user,
+            int topN
+    ) {
+        // 1) 완료된 SolvedWorkbook 전부 가져오기
+        List<SolvedWorkbook> completed = solvedWorkbookRepository
+                .findAllByUser_IdAndStatus(user.getId(), SolvingStatus.COMPLETED);
+
+        // 2) 각 Workbook별로 오답률 계산, DTO로 매핑
+        return completed.stream()
+                .map(sw -> {
+                    var logs = sw.getSolveLogs();
+                    long total   = logs.size();
+                    long wrong   = logs.stream()
+                            .filter(sl -> Boolean.FALSE.equals(sl.getIsCorrect()))
+                            .count();
+                    double rate  = total == 0 ? 0.0 : (double) wrong / total;
+                    var wb       = sw.getWorkbook();
+                    return WorkbookWrongRateResponse.of(
+                            wb.getId(),
+                            wb.getName(),
+                            rate,
+                            wrong,
+                            total
+                    );
+                })
+                // 3) 오답률 내림차순 정렬
+                .sorted(Comparator.comparingDouble(WorkbookWrongRateResponse::wrongRate).reversed())
+                // 4) 상위 topN개
+                .limit(topN)
+                .toList();
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/solve_log/service/SolveLogService.java
@@ -371,9 +371,11 @@ public class SolveLogService {
                             total
                     );
                 })
-                // 3) 오답률 내림차순 정렬
+                // 3) 오답이 있는 문제집만 필터링
+                .filter(res -> res.wrongCount() > 0)
+                // 4) 오답률 내림차순 정렬
                 .sorted(Comparator.comparingDouble(WorkbookWrongRateResponse::wrongRate).reversed())
-                // 4) 상위 topN개
+                // 5) 상위 topN개
                 .limit(topN)
                 .toList();
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package gnu.capstone.G_Learn_E.domain.user.controller;
 
+import gnu.capstone.G_Learn_E.domain.problem.dto.response.KeywordFrequencyResponse;
+import gnu.capstone.G_Learn_E.domain.problem.service.ProblemKeywordService;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.College;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Department;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
+import gnu.capstone.G_Learn_E.domain.solve_log.dto.response.WorkbookWrongRateResponse;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.*;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.*;
@@ -38,6 +41,7 @@ public class UserController {
     private final UserActivityLogService userActivityLogService;
     private final SolveLogService solveLogService;
     private final PublicFolderService publicFolderService;
+    private final ProblemKeywordService problemKeywordService;
 
     @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다.")
     @GetMapping
@@ -257,5 +261,25 @@ public class UserController {
         List<DailyActivityCountResponse> dailyCounts = userActivityLogService.getDailyCounts(user.getId(), types, days);
         Map<String, Object> response = Map.of("activityLog", dailyCounts);
         return new ApiResponse<>(HttpStatus.OK, "유저 활동 로그 조회 성공", response);
+    }
+
+    @GetMapping("/topN-wrong-keywords")
+    public ApiResponse<?> getTopNWrongKeywords(
+            @AuthenticationPrincipal User user,
+            @RequestParam(name = "topN", defaultValue = "10") int topN
+    ) {
+        List<KeywordFrequencyResponse> keywordFrequencies = problemKeywordService.getTopWrongKeywords(user, topN);
+        Map<String, Object> response = Map.of("keywords", keywordFrequencies);
+        return new ApiResponse<>(HttpStatus.OK, "유저 오답 키워드 조회 성공", response);
+    }
+
+    @GetMapping("/topN-wrong-workbooks")
+    public ApiResponse<?> getTopNWrongWorkbooks(
+            @AuthenticationPrincipal User user,
+            @RequestParam(name = "topN", defaultValue = "10") int topN
+    ) {
+        List<WorkbookWrongRateResponse> workbookWrongRates = solveLogService.getTopWrongRateWorkbooks(user, topN);
+        Map<String, Object> response = Map.of("workbooks", workbookWrongRates);
+        return new ApiResponse<>(HttpStatus.OK, "유저 오답 워크북 조회 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/controller/UserController.java
@@ -6,6 +6,8 @@ import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.service.SolveLogService;
 import gnu.capstone.G_Learn_E.domain.user.dto.request.*;
 import gnu.capstone.G_Learn_E.domain.user.dto.response.*;
+import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
+import gnu.capstone.G_Learn_E.domain.user.service.UserActivityLogService;
 import gnu.capstone.G_Learn_E.global.common.dto.serviceToController.UserPaginationResult;
 import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.entity.UserBlacklist;
@@ -22,6 +24,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -32,6 +35,7 @@ public class UserController {
 
     private final UserService userService;
     private final UserBlacklistService userBlacklistService;
+    private final UserActivityLogService userActivityLogService;
     private final SolveLogService solveLogService;
     private final PublicFolderService publicFolderService;
 
@@ -241,5 +245,17 @@ public class UserController {
     ) {
         userBlacklistService.removeBlacklist(user, request.targetId());
         return new ApiResponse<>(HttpStatus.OK, "블랙리스트 삭제 성공", null);
+    }
+
+    @Operation(summary = "유저 활동 로그 조회", description = "유저의 활동 로그를 조회합니다.")
+    @GetMapping("/activity-log")
+    public ApiResponse<?> getActivityLog(
+            @AuthenticationPrincipal User user,
+            @RequestParam(name="types") List<ActivityType> types,
+            @RequestParam(name = "days", defaultValue = "30") int days
+    ) {
+        List<DailyActivityCountResponse> dailyCounts = userActivityLogService.getDailyCounts(user.getId(), types, days);
+        Map<String, Object> response = Map.of("activityLog", dailyCounts);
+        return new ApiResponse<>(HttpStatus.OK, "유저 활동 로그 조회 성공", response);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/DailyActivityCountResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/dto/response/DailyActivityCountResponse.java
@@ -1,0 +1,15 @@
+package gnu.capstone.G_Learn_E.domain.user.dto.response;
+
+import java.time.LocalDate;
+
+public record DailyActivityCountResponse(
+        LocalDate date,
+        long      count
+) {
+    public static DailyActivityCountResponse of(
+            LocalDate date,
+            long      count
+    ) {
+        return new DailyActivityCountResponse(date, count);
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/ActivityLog.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/ActivityLog.java
@@ -2,6 +2,7 @@ package gnu.capstone.G_Learn_E.domain.user.entity;
 
 import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -37,4 +38,12 @@ public class ActivityLog {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Builder
+    public ActivityLog(
+            User         user,
+            ActivityType activityType
+    ) {
+        this.user         = user;
+        this.activityType = activityType;
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/ActivityLog.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/ActivityLog.java
@@ -1,0 +1,40 @@
+package gnu.capstone.G_Learn_E.domain.user.entity;
+
+import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+public class ActivityLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private ActivityType activityType;
+
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // 최종 수정 시각
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/entity/User.java
@@ -50,6 +50,9 @@ public class User {
     private long solvedWorkbookCount;
     private long uploadedWorkbookCount;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityLog> activityLogs = new ArrayList<>();
+
     @Setter
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "college_id", nullable = false)

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/enums/ActivityType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/enums/ActivityType.java
@@ -1,0 +1,26 @@
+package gnu.capstone.G_Learn_E.domain.user.enums;
+
+public enum ActivityType {
+    LOGIN("로그인"),
+    LOGOUT("로그아웃"),
+    SIGNUP("회원가입"),
+    PASSWORD_RESET("비밀번호 재설정"),
+    EMAIL_VERIFICATION("이메일 인증"),
+    PROFILE_UPDATE("프로필 수정"),
+    COLLEGE_UPDATE("대학 변경"),
+    DEPARTMENT_UPDATE("학과 변경"),
+    WORKBOOK_CREATE("문제집 생성"),
+    WORKBOOK_UPDATE("문제집 수정"),
+    SOLVED_WORKBOOK("문제집 풀이"),
+    WORKBOOK_UPLOAD("문제집 업로드");
+
+    private final String description;
+
+    ActivityType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/enums/ActivityType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/enums/ActivityType.java
@@ -1,5 +1,8 @@
 package gnu.capstone.G_Learn_E.domain.user.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum ActivityType {
     LOGIN("로그인"),
     LOGOUT("로그아웃"),
@@ -20,7 +23,4 @@ public enum ActivityType {
         this.description = description;
     }
 
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/ActivityLogRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/repository/ActivityLogRepository.java
@@ -1,0 +1,36 @@
+package gnu.capstone.G_Learn_E.domain.user.repository;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.ActivityLog;
+import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> {
+    @Query("""
+        SELECT FUNCTION('DATE', a.createdAt)      AS day,
+               COUNT(a)                           AS cnt
+          FROM ActivityLog a
+         WHERE a.user.id        = :userId
+           AND a.activityType   IN :types
+           AND a.createdAt      >= :startDate
+         GROUP BY FUNCTION('DATE', a.createdAt)
+         ORDER BY FUNCTION('DATE', a.createdAt)
+    """)
+    List<DailyCount> countDailyByUserAndTypesSince(
+            @Param("userId")    Long userId,
+            @Param("types")     List<ActivityType> types,
+            @Param("startDate") LocalDateTime startDate
+    );
+
+    interface DailyCount {
+        LocalDate getDay();
+        Long      getCnt();
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserActivityLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserActivityLogService.java
@@ -1,0 +1,54 @@
+package gnu.capstone.G_Learn_E.domain.user.service;
+
+import gnu.capstone.G_Learn_E.domain.user.dto.response.DailyActivityCountResponse;
+import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
+import gnu.capstone.G_Learn_E.domain.user.repository.ActivityLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserActivityLogService {
+
+    private final ActivityLogRepository activityLogRepository;
+
+    /**
+     * @param userId 조회할 유저 ID
+     * @param types  포함할 ActivityType 목록
+     * @param days   조회 기간(오늘 포함, 일수)
+     */
+    public List<DailyActivityCountResponse> getDailyCounts(
+            Long userId,
+            List<ActivityType> types,
+            int days
+    ) {
+        LocalDate today     = LocalDate.now();
+        LocalDate startDate = today.minusDays(days - 1);
+        LocalDateTime start = startDate.atStartOfDay();
+
+        // DB에서 집계
+        List<ActivityLogRepository.DailyCount> raw =
+                activityLogRepository.countDailyByUserAndTypesSince(userId, types, start);
+
+        // Map<날짜, 개수>
+        Map<LocalDate, Long> countMap = raw.stream()
+                .collect(Collectors.toMap(ActivityLogRepository.DailyCount::getDay, ActivityLogRepository.DailyCount::getCnt));
+
+        // 기간 내 모든 날짜 채우기 (존재하지 않으면 0)
+        return IntStream.range(0, days)
+                .mapToObj(i -> {
+                    LocalDate d = startDate.plusDays(i);
+                    return DailyActivityCountResponse.of(d, countMap.getOrDefault(d, 0L));
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserActivityLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserActivityLogService.java
@@ -1,11 +1,14 @@
 package gnu.capstone.G_Learn_E.domain.user.service;
 
 import gnu.capstone.G_Learn_E.domain.user.dto.response.DailyActivityCountResponse;
+import gnu.capstone.G_Learn_E.domain.user.entity.ActivityLog;
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
 import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
 import gnu.capstone.G_Learn_E.domain.user.repository.ActivityLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -50,5 +53,17 @@ public class UserActivityLogService {
                     return DailyActivityCountResponse.of(d, countMap.getOrDefault(d, 0L));
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public ActivityLog saveActivityLog(
+            ActivityType activityType,
+            User user
+    ) {
+        ActivityLog activityLog = ActivityLog.builder()
+                .user(user)
+                .activityType(activityType)
+                .build();
+        return activityLogRepository.save(activityLog);
     }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserActivityLogService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/user/service/UserActivityLogService.java
@@ -47,7 +47,7 @@ public class UserActivityLogService {
                 .collect(Collectors.toMap(ActivityLogRepository.DailyCount::getDay, ActivityLogRepository.DailyCount::getCnt));
 
         // 기간 내 모든 날짜 채우기 (존재하지 않으면 0)
-        return IntStream.range(0, days)
+        return IntStream.range(0, days + 1)
                 .mapToObj(i -> {
                     LocalDate d = startDate.plusDays(i);
                     return DailyActivityCountResponse.of(d, countMap.getOrDefault(d, 0L));

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -7,6 +7,7 @@ import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
 import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
+import gnu.capstone.G_Learn_E.domain.user.entity.ActivityLog;
 import gnu.capstone.G_Learn_E.domain.user.entity.UserLevelPolicy;
 import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
 import gnu.capstone.G_Learn_E.domain.user.service.UserActivityLogService;

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -8,6 +8,8 @@ import gnu.capstone.G_Learn_E.domain.public_folder.entity.Subject;
 import gnu.capstone.G_Learn_E.domain.public_folder.service.PublicFolderService;
 import gnu.capstone.G_Learn_E.domain.solve_log.dto.request.SaveSolveLogRequest;
 import gnu.capstone.G_Learn_E.domain.user.entity.UserLevelPolicy;
+import gnu.capstone.G_Learn_E.domain.user.enums.ActivityType;
+import gnu.capstone.G_Learn_E.domain.user.service.UserActivityLogService;
 import gnu.capstone.G_Learn_E.domain.user.service.UserService;
 import gnu.capstone.G_Learn_E.domain.workbook.converter.WorkbookConverter;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.*;
@@ -49,6 +51,7 @@ public class WorkbookController {
     private final WorkbookVoteService workbookVoteService;
     private final SolveLogService solveLogService;
     private final FastApiService fastApiService;
+    private final UserActivityLogService userActivityLogService;
 
 
     @GetMapping("/{workbookId}")
@@ -82,6 +85,8 @@ public class WorkbookController {
 
         WorkbookResponse response = WorkbookResponse.of(workbook);
 
+        // 유저 행동 로그 저장
+        userActivityLogService.saveActivityLog(ActivityType.WORKBOOK_CREATE, user);
         // 유저의 문제집 생성 개수 증가
         userService.plusCreateWorkbookCount(user);
         // 문제집 생성 시 경험치 부여
@@ -198,6 +203,9 @@ public class WorkbookController {
             );
         }
 
+        // 유저 행동 로그 저장
+        userActivityLogService.saveActivityLog(ActivityType.SOLVED_WORKBOOK, user);
+
         return new ApiResponse<>(HttpStatus.OK, "문제 풀이 채점 성공", response);
     }
 
@@ -217,6 +225,8 @@ public class WorkbookController {
                 subject.getName()
         );
         userService.gainExp(user, UserLevelPolicy.EXP_UPLOAD_WORKBOOK);
+        // 유저 행동 로그 저장
+        userActivityLogService.saveActivityLog(ActivityType.WORKBOOK_UPLOAD, user);
         return new ApiResponse<>(HttpStatus.OK, "문제집 업로드 성공", response);
     }
 
@@ -266,6 +276,8 @@ public class WorkbookController {
     ){
         Workbook workbook = workbookService.createWorkbookFromProblems(request.title(), request.problems(), user);
         WorkbookResponse response = WorkbookResponse.of(workbook);
+        // 유저 행동 로그 저장
+        userActivityLogService.saveActivityLog(ActivityType.WORKBOOK_UPDATE, user);
         return new ApiResponse<>(HttpStatus.OK, "문제집 병합 성공", response);
     }
 
@@ -301,6 +313,8 @@ public class WorkbookController {
         solveLogService.deleteAllLogByWorkbook(workbookId);
         Workbook workbook = workbookService.replaceProblemsInWorkbook(workbookId, request.problems(), user);
         WorkbookSimpleResponse response = WorkbookSimpleResponse.from(workbook);
+        // 유저 행동 로그 저장
+        userActivityLogService.saveActivityLog(ActivityType.WORKBOOK_UPDATE, user);
         return new ApiResponse<>(HttpStatus.OK, "문제집 문제 수정 성공", response);
     }
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/controller/WorkbookController.java
@@ -336,4 +336,17 @@ public class WorkbookController {
         WorkbookSimpleResponse response = WorkbookSimpleResponse.from(workbook);
         return new ApiResponse<>(HttpStatus.OK, "문제집 투표 성공", response);
     }
+
+    @Operation(summary = "문제집 연관 키워드 조회", description = "키워드와 가장 유사한 문제집을 조회합니다.")
+    @GetMapping("/relative-keyword")
+    public ApiResponse<?> getRelativeKeyword(
+            @AuthenticationPrincipal User user,
+            @RequestParam("keyword") String keyword,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size
+    ) {
+        log.info("문제집 연관 키워드 조회 요청 : {}", keyword);
+        List<WorkbookSimpleResponse> response = workbookService.getWorkbooksByRelativeKeyword(user, keyword, page, size);
+        return new ApiResponse<>(HttpStatus.OK, "연관 키워드 문제집 조회 성공", response);
+    }
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpdateRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookUpdateRequest.java
@@ -1,10 +1,12 @@
 package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
 
+import gnu.capstone.G_Learn_E.domain.workbook.enums.ExamType;
+import gnu.capstone.G_Learn_E.domain.workbook.enums.Semester;
+
 public record WorkbookUpdateRequest(
         String name,
         String professor,
         String examType,
-        Integer coverImage,
         Integer courseYear,
         String semester
 ) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookVoteRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/request/WorkbookVoteRequest.java
@@ -1,6 +1,8 @@
 package gnu.capstone.G_Learn_E.domain.workbook.dto.request;
 
+import gnu.capstone.G_Learn_E.domain.workbook.enums.WorkbookVoteType;
+
 public record WorkbookVoteRequest(
-        String voteType
+        WorkbookVoteType voteType
 ) {
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookProfileResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookProfileResponse.java
@@ -1,0 +1,72 @@
+package gnu.capstone.G_Learn_E.domain.workbook.dto.response;
+
+import gnu.capstone.G_Learn_E.domain.user.entity.User;
+import gnu.capstone.G_Learn_E.domain.workbook.entity.Workbook;
+import gnu.capstone.G_Learn_E.global.common.dto.response.Author;
+
+public record WorkbookProfileResponse(
+        Long id, // 문제집 ID
+        String name, // 워크북 이름
+        String professor, // 교수 이름
+        String examType, // 시험 유형
+        Integer coverImage, // 표지 이미지
+        Integer courseYear, // 수강 연도
+        String semester, // 학기
+        String createdAt, // 생성일
+        long problemCount, // 문제 수
+        long likeCount, // 좋아요 수
+        long dislikeCount, // 싫어요 수
+        Author author // 작성자 정보
+) {
+
+    public static WorkbookProfileResponse of(
+            Long id,
+            String name,
+            String professor,
+            String examType,
+            Integer coverImage,
+            Integer courseYear,
+            String semester,
+            String createdAt,
+            long problemCount,
+            long likeCount,
+            long dislikeCount,
+            Author author
+    ) {
+        return new WorkbookProfileResponse(
+                id,
+                name,
+                professor,
+                examType,
+                coverImage,
+                courseYear,
+                semester,
+                createdAt,
+                problemCount,
+                likeCount,
+                dislikeCount,
+                author
+        );
+    }
+
+    public static WorkbookProfileResponse from(
+            Workbook workbook,
+            long problemCount,
+            User author
+    ) {
+        return new WorkbookProfileResponse(
+                workbook.getId(),
+                workbook.getName(),
+                workbook.getProfessor(),
+                workbook.getExamType().getLabel(),
+                workbook.getCoverImage(),
+                workbook.getCourseYear(),
+                workbook.getSemester().getLabel(),
+                workbook.getCreatedAt().toString(),
+                problemCount,
+                workbook.getLikeCount(),
+                workbook.getDislikeCount(),
+                Author.from(author)
+        );
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookSimpleResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/dto/response/WorkbookSimpleResponse.java
@@ -46,10 +46,10 @@ public record WorkbookSimpleResponse(
                 workbook.getId(),
                 workbook.getName(),
                 workbook.getProfessor(),
-                workbook.getExamType().name(),
+                workbook.getExamType().getLabel(),
                 workbook.getCoverImage(),
                 workbook.getCourseYear(),
-                workbook.getSemester().name(),
+                workbook.getSemester().getLabel(),
                 workbook.getCreatedAt().toString(),
                 workbook.getLikeCount(),
                 workbook.getDislikeCount()

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/ExamType.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/ExamType.java
@@ -1,12 +1,18 @@
 package gnu.capstone.G_Learn_E.domain.workbook.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum ExamType {
 
-    ALL, // 전체 범위
-    MIDDLE, // 중간고사
-    FINAL, // 기말고사
-    OTHER // 기타
+    ALL("전체"), // 전체 범위
+    MIDDLE("중간고사"), // 중간고사
+    FINAL("기말고사"), // 기말고사
+    OTHER("기타") // 기타
     ;
+
+    private final String label;
+    ExamType(String label) { this.label = label; }
 
     public static ExamType fromString(String examType) {
         for (ExamType type : ExamType.values()) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/Semester.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/enums/Semester.java
@@ -1,12 +1,20 @@
 package gnu.capstone.G_Learn_E.domain.workbook.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum Semester {
-    SPRING, // 1학기
-    SUMMER, // 여름 계절학기
-    FALL, // 2학기
-    WINTER, // 겨울 계절학기
-    OTHER // 기타
+    SPRING("1학기"), // 1학기
+    SUMMER("여름 계절학기"), // 여름 계절학기
+    FALL("2학기"), // 2학기
+    WINTER("겨울 계절학기"), // 겨울 계절학기
+    OTHER("기타") // 기타
     ;
+
+    private final String label;
+    Semester(String label) {
+        this.label = label;
+    }
 
     public static Semester fromString(String semester) {
         for (Semester sem : Semester.values()) {

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -28,7 +28,8 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long>, JpaSp
 
     @EntityGraph(attributePaths = {
             "problemWorkbookMaps",
-            "problemWorkbookMaps.problem"
+            "problemWorkbookMaps.problem",
+            "author"
     })
     Optional<Workbook> findWithMappingsAndProblemsById(@Param("workbookId") Long workbookId);
 

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/repository/WorkbookRepository.java
@@ -158,4 +158,28 @@ public interface WorkbookRepository extends JpaRepository<Workbook, Long>, JpaSp
             @Param("currentUserId") Long currentUserId,
             Pageable pageable
     );
+
+    @Query("""
+        SELECT DISTINCT w
+          FROM Workbook w
+          JOIN w.problemWorkbookMaps pwm
+          JOIN pwm.problem p
+          JOIN p.problemKeywords pk
+          LEFT JOIN w.folderWorkbookMaps fwm
+          LEFT JOIN w.subjectWorkbookMaps swm
+         WHERE pk.keyword = :keyword
+           AND (
+               fwm.folder.user.id = :userId
+               OR swm IS NOT NULL
+           )
+    """)
+    @EntityGraph(attributePaths = {
+            "problemWorkbookMaps",
+            "problemWorkbookMaps.problem",
+            "problemWorkbookMaps.problem.problemKeywords"
+    })
+    List<Workbook> findAccessibleByKeyword(
+            @Param("keyword") String keyword,
+            @Param("userId")  Long userId
+    );
 }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookService.java
@@ -318,14 +318,17 @@ public class WorkbookService {
     }
 
     public Workbook updateWorkbook(Long workbookId, WorkbookUpdateRequest request) {
+        ExamType examType = ExamType.valueOf(request.examType());
+        Semester semester = Semester.valueOf(request.semester());
+
         Workbook workbook = findWorkbookById(workbookId);
         workbook.updateWorkbook(
                 request.name(),
                 request.professor(),
-                ExamType.fromString(request.examType()),
-                request.coverImage(),
+                examType,
+                workbook.getCoverImage(),
                 request.courseYear(),
-                Semester.fromString(request.semester())
+                semester
         );
         return workbookRepository.save(workbook);
     }

--- a/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookVoteService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/domain/workbook/service/WorkbookVoteService.java
@@ -22,8 +22,7 @@ public class WorkbookVoteService {
     private final WorkbookVoteRepository workbookVoteRepository;
 
     @Transactional
-    public void toggleVote(Workbook workbook, User user, String voteTypeStr) {
-        WorkbookVoteType workbookVoteType = (voteTypeStr.equalsIgnoreCase("like")) ? WorkbookVoteType.LIKE : WorkbookVoteType.DISLIKE;
+    public void toggleVote(Workbook workbook, User user, WorkbookVoteType voteType) {
 
         Optional<WorkbookVote> voteOpt = workbookVoteRepository.findByUserIdAndWorkbookId(user.getId(), workbook.getId());
         if(voteOpt.isEmpty()){
@@ -32,18 +31,18 @@ public class WorkbookVoteService {
             WorkbookVote workbookVote = WorkbookVote.builder()
                     .user(user)
                     .workbook(workbook)
-                    .voteType(workbookVoteType)
+                    .voteType(voteType)
                     .build();
             workbookVoteRepository.save(workbookVote);
         } else {
             // 사용자가 이미 투표한 경우, 투표를 토글합니다.
             WorkbookVote existingVote = voteOpt.get();
-            if (existingVote.getVoteType() == workbookVoteType) {
+            if (existingVote.getVoteType() == voteType) {
                 // 같은 투표를 다시 클릭하면 투표를 제거합니다.
                 workbookVoteRepository.delete(existingVote);
             } else {
                 // 다른 투표를 클릭하면 기존 투표를 업데이트합니다.
-                existingVote.setVoteType(workbookVoteType);
+                existingVote.setVoteType(voteType);
                 workbookVoteRepository.save(existingVote);
             }
         }

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/controller/FastApiController.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/controller/FastApiController.java
@@ -1,5 +1,8 @@
 package gnu.capstone.G_Learn_E.global.fastapi.controller;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.domain.problem.service.ProblemService;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.QuestionTypes;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.request.GradeBlankRequest;
@@ -12,10 +15,7 @@ import gnu.capstone.G_Learn_E.global.template.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,6 +26,17 @@ import java.util.List;
 public class FastApiController {
 
     private final FastApiService fastApiService;
+    private final ProblemRepository problemRepository;
+
+    @PostMapping("/test/extract-keywords")
+    public ApiResponse<ExtractKeywordsResponse> testExtractKeywords() {
+        List<Problem> problems = problemRepository.findRandomProblems(5);
+        int topN = 3;
+
+        ExtractKeywordsResponse response = fastApiService.extractKeywordsFromProblems(problems, topN);
+        log.info("FastAPI Request success");
+        return new ApiResponse<>(HttpStatus.OK, "키워드 추출에 성공하였습니다.", response);
+    }
 
 
     @GetMapping("/test/make-problem")

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/ExtractKeywordsRequest.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/request/ExtractKeywordsRequest.java
@@ -1,0 +1,54 @@
+package gnu.capstone.G_Learn_E.global.fastapi.dto.request;
+
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.global.common.serialization.Option;
+
+import java.util.List;
+
+public record ExtractKeywordsRequest(
+    List<ProblemDTO> problems,
+    int topN
+) {
+
+    public static ExtractKeywordsRequest from(List<Problem> problems, int topN) {
+        List<ProblemDTO> problemDTOs = problems.stream()
+                .map(ProblemDTO::from)
+                .toList();
+        return new ExtractKeywordsRequest(problemDTOs, topN);
+    }
+
+
+    private record ProblemDTO(
+            Long id,
+            String title,
+            List<OptionDTO> options,
+            List<String> answers,
+            String explanation,
+            String type
+    ) {
+        public static ProblemDTO from(Problem problem) {
+            List<OptionDTO> options = (problem.getOptions()==null)
+                    ? List.of()
+                    : problem.getOptions().stream()
+                    .map(OptionDTO::from).toList();
+            return new ProblemDTO(
+                    problem.getId(),
+                    problem.getTitle(),
+                    options,
+                    problem.getAnswers(),
+                    problem.getExplanation(),
+                    problem.getType().toString()
+            );
+        }
+    }
+
+    private record OptionDTO(
+            Short number,
+            String content
+    ) {
+        public static OptionDTO from(Option option) {
+            return new OptionDTO(option.getNumber(), option.getContent());
+        }
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/ExtractKeywordsResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/ExtractKeywordsResponse.java
@@ -8,7 +8,7 @@ public record ExtractKeywordsResponse(
         int responseTokens,
         float estimatedCostKrw
 ) {
-    record ProblemKeyword(
+    public record ProblemKeyword(
             Long id,
             List<String> keywords
     ) {

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/ExtractKeywordsResponse.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/dto/response/ExtractKeywordsResponse.java
@@ -1,0 +1,16 @@
+package gnu.capstone.G_Learn_E.global.fastapi.dto.response;
+
+import java.util.List;
+
+public record ExtractKeywordsResponse(
+        List<ProblemKeyword> problems,
+        int requestTokens,
+        int responseTokens,
+        float estimatedCostKrw
+) {
+    record ProblemKeyword(
+            Long id,
+            List<String> keywords
+    ) {
+    }
+}

--- a/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/service/FastApiService.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/fastapi/service/FastApiService.java
@@ -1,5 +1,6 @@
 package gnu.capstone.G_Learn_E.global.fastapi.service;
 
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.request.ProblemGenerateRequest;
 import gnu.capstone.G_Learn_E.domain.workbook.dto.response.ProblemGenerateResponse;
 import gnu.capstone.G_Learn_E.global.fastapi.dto.request.*;
@@ -37,6 +38,23 @@ public class FastApiService {
 
     private FastApiProperties.Endpoint getEndpoint(String endpointName) {
         return fastApiProperties.endpoints().get(endpointName);
+    }
+
+    public ExtractKeywordsResponse extractKeywordsFromProblems(List<Problem> problems, int topN) {
+        FastApiProperties.Endpoint endpoint = getEndpoint("extract-keywords");
+        String url = fastApiProperties.baseUrl() + endpoint.path();
+
+        ExtractKeywordsRequest request = ExtractKeywordsRequest.from(problems, topN);
+
+        // FastAPI 서버로 POST 요청
+        ResponseEntity<ExtractKeywordsResponse> response = restTemplate.postForEntity(url, request, ExtractKeywordsResponse.class);
+        if (response.getStatusCode().is2xxSuccessful()) {
+            log.info("FastAPI response: {}", response.getBody());
+            return response.getBody();
+        } else {
+            log.error("Failed to call FastAPI: {}", response.getStatusCode());
+            throw new RuntimeException("Failed to call FastAPI");
+        }
     }
 
 

--- a/src/main/java/gnu/capstone/G_Learn_E/global/scheduler/KeywordGenerateScheduler.java
+++ b/src/main/java/gnu/capstone/G_Learn_E/global/scheduler/KeywordGenerateScheduler.java
@@ -1,0 +1,61 @@
+package gnu.capstone.G_Learn_E.global.scheduler;
+
+
+import gnu.capstone.G_Learn_E.domain.problem.entity.Problem;
+import gnu.capstone.G_Learn_E.domain.problem.entity.ProblemKeyword;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemKeywordRepository;
+import gnu.capstone.G_Learn_E.domain.problem.repository.ProblemRepository;
+import gnu.capstone.G_Learn_E.global.fastapi.dto.response.ExtractKeywordsResponse;
+import gnu.capstone.G_Learn_E.global.fastapi.service.FastApiService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KeywordGenerateScheduler {
+
+    private final ProblemRepository problemRepository;
+    private final ProblemKeywordRepository problemKeywordRepository;
+    private final FastApiService fastApiService;
+
+    @Value("${keywords-per-problem}")
+    private int keywordsPerProblem;
+
+    @Transactional
+    public void keywordGenerate() {
+        // TODO : 예외 발생 시 다음 문제 키워드 추출 안되는 구조 수정해야 함
+        List<Problem> problems = problemRepository.findByProblemKeywordsIsEmpty(PageRequest.of(0, 5)).getContent();
+        ExtractKeywordsResponse extractKeywordsResponse = fastApiService.extractKeywordsFromProblems(problems, keywordsPerProblem);
+
+        for(ExtractKeywordsResponse.ProblemKeyword problemKeyword : extractKeywordsResponse.problems()) {
+            saveProblemKeywords(problemKeyword.id(), problemKeyword.keywords());
+        }
+
+    }
+
+    @Transactional
+    protected void saveProblemKeywords(Long problemId, List<String> keywords) {
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new IllegalArgumentException("Problem not found with id: " + problemId));
+
+        AtomicInteger priority = new AtomicInteger(1);
+
+        List<ProblemKeyword> problemKeywords = keywords.stream()
+                .map(keyword -> ProblemKeyword.builder()
+                        .priority(priority.getAndIncrement())
+                        .problem(problem)
+                        .keyword(keyword)
+                        .build())
+                .toList();
+        problemKeywordRepository.saveAll(problemKeywords);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,3 +128,6 @@ fast-api:
     monthly-logs:
       method: ${fast-api.endpoints.monthly-logs.method}
       path: ${fast-api.endpoints.monthly-logs.path}
+    extract-keywords:
+      method: ${fast-api.endpoints.extract-keywords.method}
+      path: ${fast-api.endpoints.extract-keywords.path}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,7 @@ mail-auth:
     - gnu.ac.kr
     - gmail.com
 
+keywords-per-problem: 5
 
 security:
   path:

--- a/src/test/java/gnu/capstone/G_Learn_E/global/jwt/JwtUtilsTest.java
+++ b/src/test/java/gnu/capstone/G_Learn_E/global/jwt/JwtUtilsTest.java
@@ -15,12 +15,13 @@ public class JwtUtilsTest {
     private JwtUtils jwtUtils;
     private final String secretKey = Base64.getEncoder().encodeToString("my-very-secret-key-my-very-secret-key".getBytes());
     private final long accessTokenExpiration = 1000 * 60 * 60; // 1시간
+    private final long passwordResetTokenExpiration = 1000 * 60 * 10; // 10분
     private final long refreshTokenExpiration = 1000 * 60 * 60 * 24 * 7; // 7일
     private final long emailAuthTokenExpiration = 1000 * 60 * 5; // 5분
 
     @BeforeEach
     void setUp() {
-        jwtUtils = new JwtUtils(secretKey, emailAuthTokenExpiration, accessTokenExpiration, refreshTokenExpiration);
+        jwtUtils = new JwtUtils(secretKey, emailAuthTokenExpiration, passwordResetTokenExpiration, accessTokenExpiration, refreshTokenExpiration);
     }
 
     @Test
@@ -40,7 +41,7 @@ public class JwtUtilsTest {
     void validateToken_만료된토큰도_true() throws InterruptedException {
         // given
         User user = User.builder().email("expired@example.com").nickname("expiredUser").build();
-        JwtUtils shortLivedJwt = new JwtUtils(secretKey, emailAuthTokenExpiration, 1, refreshTokenExpiration);
+        JwtUtils shortLivedJwt = new JwtUtils(secretKey, emailAuthTokenExpiration, 1, 1, refreshTokenExpiration);
         String token = shortLivedJwt.generateAccessToken(user);
         Thread.sleep(5); // 토큰 만료까지 대기
 
@@ -80,7 +81,7 @@ public class JwtUtilsTest {
     void isExpired_만료된토큰이면_true() throws InterruptedException {
         // given
         User user = User.builder().email("expired2@example.com").nickname("expiredUser2").build();
-        JwtUtils shortLivedJwt = new JwtUtils(secretKey, emailAuthTokenExpiration, 1, refreshTokenExpiration);
+        JwtUtils shortLivedJwt = new JwtUtils(secretKey, emailAuthTokenExpiration, 1, 1, refreshTokenExpiration);
         String token = shortLivedJwt.generateAccessToken(user);
         Thread.sleep(5); // 만료 대기
 


### PR DESCRIPTION
## #️⃣ Issue Number
#83

## 📝 요약(Summary)
- `DevProblemController` 추가: 문제 키워드 추출 API 연동
- `ProblemKeywordService` 및 관련 엔티티/레포지토리 구현
- FastAPI 연동 통한 키워드 추출 로직 추가
- 사용자 풀이 로그 기반 오답 키워드, 문제집 통계 API 구현
- 유저 활동 로그 수집 및 조회 기능 추가
- 문제집 관련 키워드 기반 추천 API 추가
- 문제집 표기 관련 enum (`ExamType`, `Semester`)에 라벨 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정

## 📝 상세 설명(Details)
1. **문제 키워드 추출 API 연동 및 서비스 구현**
   - `DevProblemController`에 `/extract-keywords` 엔드포인트 구현
   - `ProblemKeywordService`를 통해 키워드 저장 로직 구현
   - 실패한 키워드 추출 문제는 `FailedKeywordGenerate` 테이블에 기록되도록 구현

2. **문제 키워드 추출 스케쥴러 추가**
   - 1분마다 실행되는 `KeywordGenerateScheduler` 추가
   - 오류 발생 시에도 이후 작업이 정상 수행되도록 예외 처리 개선

3. **FastAPI 연동**
   - FastAPI 서버로 문제 리스트를 보내 키워드를 추출하고 응답 파싱
   - `ExtractKeywordsRequest`, `ExtractKeywordsResponse` DTO 구성

4. **오답 기반 통계 API**
   - `UserController`에 `/topN-wrong-keywords`, `/topN-wrong-workbooks` 엔드포인트 추가
   - 오답 문제에 포함된 키워드의 빈도수 통계 및 문제집별 오답률 상위 N개 조회

5. **유저 활동 로그 수집 기능**
   - `ActivityLog` 엔티티 및 `ActivityLogRepository` 구현
   - `UserActivityLogService`에서 일별 활동 통계 제공
   - `UserController`에서 `/activity-log` API 제공

6. **문제집 관련 API 개선**
   - `WorkbookController`에서 문제집 조회 시 작성자 및 문제 수 포함된 상세 응답(`WorkbookProfileResponse`) 제공
   - `WorkbookService`에서 키워드를 기반으로 관련 문제집 추천 로직 구현

7. **enum 라벨 추가**
   - `ExamType`, `Semester` enum에 사용자 친화적인 `label` 필드 추가
   - API 응답에 label 사용되도록 컨버팅 로직 수정

8. **버그 수정 및 마무리**
   - 세션 오류 (`No Session`) 및 유저 행동 로그 범위 수정
   - 키워드 추출 최종 테스트 및 마무리

## 📸스크린샷 (선택)
- 없음

## 💬 공유사항 to 리뷰어
- `DevProblemController`의 예외 처리 로직이 다소 중첩되어 있으므로 개선 방향에 대해 피드백 부탁드립니다.
- FastAPI 연동 시 네트워크 오류 등 외부 요인 대응 방안에 대해 논의가 필요합니다.
